### PR TITLE
chore: update CSI sidecar images to latest versions

### DIFF
--- a/deploy/csi-xenorchestra-controller-dev.yaml
+++ b/deploy/csi-xenorchestra-controller-dev.yaml
@@ -48,7 +48,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
           args:
             - --csi-address=/csi/csi.sock
             - --http-endpoint=localhost:29602
@@ -104,7 +104,7 @@ spec:
           #     cpu: 10m
           #     memory: 20Mi
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/deploy/csi-xenorchestra-controller.yaml
+++ b/deploy/csi-xenorchestra-controller.yaml
@@ -45,7 +45,7 @@ spec:
       containers:
         # TODO: Add provisioner, attacher, resizer, snapshotter implementation when ready
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
           args:
             - --csi-address=/csi/csi.sock
             - --http-endpoint=localhost:29602
@@ -106,7 +106,7 @@ spec:
               drop:
                 - ALL
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/deploy/csi-xenorchestra-node-single.yaml
+++ b/deploy/csi-xenorchestra-node-single.yaml
@@ -36,7 +36,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
           args:
             - --csi-address=/csi/csi.sock
             - --http-endpoint=localhost:29603
@@ -52,7 +52,7 @@ spec:
               drop:
                 - ALL
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.15.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
           args:
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/snap/microk8s/common/var/lib/kubelet/plugins/csi.xenorchestra.vates.tech/csi.sock

--- a/deploy/csi-xenorchestra-node.yaml
+++ b/deploy/csi-xenorchestra-node.yaml
@@ -37,7 +37,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
           args:
             - --csi-address=/csi/csi.sock
             - --http-endpoint=localhost:29603
@@ -53,7 +53,7 @@ spec:
               drop:
                 - ALL
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.15.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
           args:
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/snap/microk8s/common/var/lib/kubelet/plugins/csi.xenorchestra.vates.tech/csi.sock


### PR DESCRIPTION
## Summary

Updates all Kubernetes CSI sidecar container images across the deployment manifests to their latest stable releases.

## Changes

| Image | Previous | Latest |
|---|---|---|
| `registry.k8s.io/sig-storage/livenessprobe` | `v2.17.0` | `v2.18.0` |
| `registry.k8s.io/sig-storage/csi-attacher` | `v4.10.0` | `v4.11.0` |
| `registry.k8s.io/sig-storage/csi-node-driver-registrar` | `v2.15.0` | `v2.16.0` |

## Additional fix

The `csi-node-driver-registrar` image reference in node manifests was using the deprecated `k8s.gcr.io` registry. Migrated to the canonical `registry.k8s.io` registry.

## Files affected

- `deploy/csi-xenorchestra-controller.yaml`
- `deploy/csi-xenorchestra-controller-dev.yaml`
- `deploy/csi-xenorchestra-node.yaml`
- `deploy/csi-xenorchestra-node-single.yaml`

## References

- [livenessprobe v2.18.0](https://github.com/kubernetes-csi/livenessprobe/releases/tag/v2.18.0) — released 2026-02-13
- [external-attacher v4.11.0](https://github.com/kubernetes-csi/external-attacher/releases/tag/v4.11.0) — released 2026-02-13
- [node-driver-registrar v2.16.0](https://github.com/kubernetes-csi/node-driver-registrar/releases/tag/v2.16.0) — released 2026-02-13