### PR TITLE
Feat/load config from env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,15 @@ ARG GIT_COMMIT
 
 WORKDIR /build
 COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
 COPY Makefile ./
 COPY pkg/    pkg/
 COPY cmd/    cmd/
-RUN VERSION="${VERSION}" GIT_COMMIT="${GIT_COMMIT}" make build-all-archs
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    VERSION="${VERSION}" GIT_COMMIT="${GIT_COMMIT}" make build-all-archs
 
 
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Name | Meaning | Example | Required | Default
 
 ### Security & Configuration
 - [ ] Use with Xen Orchestra Cloud Controller Manager
-- [ ] Alternative for credential management (env variables?)
+- [x] Alternative for credential management (environment variables supported)
 - [ ] Check RBAC policies
 
 ### Performance & Monitoring

--- a/deploy/csi-xenorchestra-controller-dev.yaml
+++ b/deploy/csi-xenorchestra-controller-dev.yaml
@@ -11,6 +11,8 @@ metadata:
     app.kubernetes.io/component: plugin
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: csi-xenorchestra-controller

--- a/deploy/csi-xenorchestra-node-single.yaml
+++ b/deploy/csi-xenorchestra-node-single.yaml
@@ -11,6 +11,8 @@ metadata:
     app.kubernetes.io/component: plugin
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: csi-xenorchestra-node-single

--- a/deploy/csi-xenorchestra-node-single.yaml
+++ b/deploy/csi-xenorchestra-node-single.yaml
@@ -98,6 +98,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+          # Uncomment to use env from secret instead of mounted config file for local dev
+          # envFrom:
+          #   - secretRef:
+          #       name: xo-config
           securityContext:
             privileged: true
             capabilities:

--- a/docs/install.md
+++ b/docs/install.md
@@ -73,6 +73,48 @@ kubectl -n kube-system create secret generic xenorchestra-cloud-controller-manag
 
 > ℹ️ The secret name `xenorchestra-cloud-controller-manager` is shared with the CCM by convention.
 
+### Alternative: Environment Variable Configuration
+
+Instead of using a config file secret, you can configure the driver using environment variables.
+This can be useful for development or testing scenarios.
+
+The driver supports the following environment variables:
+
+| Variable | Description | Required | Default |
+| -------- | ----------- | -------- | ------- |
+| `XOA_URL` | Xen Orchestra API URL | Yes | — |
+| `XOA_TOKEN` | API token for authentication | Yes (if not using username/password) | — |
+| `XOA_INSECURE` | Skip TLS verification | No | `false` |
+
+**Example:**
+
+Create a `.env` file (e.g., `xo-config.env`):
+
+```env
+# Xen Orchestra configuration
+XOA_URL=https://xo.example.com
+XOA_TOKEN="your-api-token-here"
+XOA_INSECURE=false
+```
+
+Then create a secret from the `.env` file:
+
+```bash
+# Create secret from .env file
+kubectl -n kube-system create secret generic xenorchestra-config \
+  --from-env-file=xo-config.env
+```
+
+```yaml
+# In your deployment manifest
+envFrom:
+  - secretRef:
+      name: xenorchestra-config
+```
+
+> ⚠️ **Note:** Environment variables take precedence only when the config file is not found.
+> The driver first tries to load configuration from the mounted config file, and falls back to environment variables if the file is missing or invalid.
+
 ### 3. Install the driver
 
 Using the installation script (recommended):
@@ -94,6 +136,24 @@ The script applies the following manifests in order:
 | `csi-xenorchestra-node.yaml` | Node plugin `DaemonSet` |
 | `rbac-csi-xenorchestra-controller.yaml` | Controller RBAC |
 | `csi-xenorchestra-controller.yaml` | Controller `StatefulSet` |
+
+**Customizing for Environment Variables:**
+
+If you want to use environment variables instead of the config file, modify the controller deployment:
+
+```yaml
+# In deploy/csi-xenorchestra-controller.yaml
+containers:
+  - name: xenorchestra-csi-driver
+    # ... existing args ...
+    envFrom:
+      - secretRef:
+          name: xenorchestra-config  # Secret created from .env file
+    # Remove or comment out the config-file volume mount
+    # volumeMounts:
+    #   - name: xenorchestra-config
+    #     mountPath: /etc/xenorchestra
+```
 
 Verify that the pods are running:
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/protobuf v1.5.4
 	github.com/vatesfr/xenorchestra-go-sdk v1.13.0
-	github.com/vatesfr/xenorchestra-k8s-common v0.1.0
+	github.com/vatesfr/xenorchestra-k8s-common v0.2.0
 	google.golang.org/grpc v1.79.1
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/vatesfr/xenorchestra-go-sdk v1.13.0 h1:DxEhI0wjCQriFTRd4+/TRMgl5Xa9ASzZsJ4/zAbYWyg=
 github.com/vatesfr/xenorchestra-go-sdk v1.13.0/go.mod h1:dtzYbQzologbcww09XQ2QOM3wLa/OFi7jO5L9R7aSM0=
-github.com/vatesfr/xenorchestra-k8s-common v0.1.0 h1:VF9sDftxOKW8xc8kxGmX/4Idjud5T3hf1IdixieXilM=
-github.com/vatesfr/xenorchestra-k8s-common v0.1.0/go.mod h1:o/LRNwZ9LEZlepephpWttXjl0LcRdHHHdP3cinTBvug=
+github.com/vatesfr/xenorchestra-k8s-common v0.2.0 h1:o1wg0pAQs4EkZWtGByUSm38J1diBwxjypGQkScvRHqo=
+github.com/vatesfr/xenorchestra-k8s-common v0.2.0/go.mod h1:o/LRNwZ9LEZlepephpWttXjl0LcRdHHHdP3cinTBvug=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/pkg/xenorchestra-csi/controllerserver.go
+++ b/pkg/xenorchestra-csi/controllerserver.go
@@ -138,8 +138,7 @@ func (driver *xenorchestraCSIDriver) ControllerPublishVolume(ctx context.Context
 			}
 		}
 		if vbdToAttach != nil {
-			// If we found a VBD for this VM, connect it if needed
-			// The VDI is already added to the VM
+			// The VDI is already added to this VM; connect it if not yet hot-plugged.
 			if !vbdToAttach.Attached {
 				klog.V(5).InfoS("Connecting existing VBD to VM", "vbd", *vbdToAttach, "vmUUID", vmUUID)
 				vbdConnected, err := driver.xoClient.ConnectVBDToVM(ctx, *vbdToAttach)
@@ -151,12 +150,11 @@ func (driver *xenorchestraCSIDriver) ControllerPublishVolume(ctx context.Context
 				return &csi.ControllerPublishVolumeResponse{
 					PublishContext: publishContextFromVBD(*vbdConnected),
 				}, nil
-			} else {
-				klog.V(2).InfoS("VDI already attached to the node", "vbd", vbdToAttach)
-				return &csi.ControllerPublishVolumeResponse{
-					PublishContext: publishContextFromVBD(*vbdToAttach),
-				}, nil
 			}
+			klog.V(2).InfoS("VDI already attached to the node", "vbd", vbdToAttach)
+			return &csi.ControllerPublishVolumeResponse{
+				PublishContext: publishContextFromVBD(*vbdToAttach),
+			}, nil
 		} else {
 			// Else, it means the VDI is added to a VM (= has VBD) but is not attached (connected) to it
 			// We can continue to attach it to the node

--- a/pkg/xenorchestra-csi/xenorchestra-csi.go
+++ b/pkg/xenorchestra-csi/xenorchestra-csi.go
@@ -75,7 +75,11 @@ func NewDriver(options *DriverOptions) Driver {
 	xoConfig, err := LoadXOConfigFromFile(options.ConfigFile)
 	if err != nil {
 		klog.Warningf("Failed to load config from file %s: %v, falling back to environment variables", options.ConfigFile, err)
-		// TODO: Add fallback to env variables
+		// Load XO config from environment variables if file loading fails
+		xoConfig, err = xok8s.LoadXOConfigFromEnv()
+		if err != nil {
+			klog.Fatalf("Failed to load config from environment variables: %v. Please ensure either a valid config file is mounted or the required environment variables (XOA_URL and XOA_TOKEN) are set", err)
+		}
 	}
 	xoClient, err := xok8s.NewXOClient(&xoConfig)
 	if err != nil {

--- a/pkg/xenorchestra-csi/xoclient.go
+++ b/pkg/xenorchestra-csi/xoclient.go
@@ -97,7 +97,7 @@ func (c xoClient) AttachVDIToVM(ctx context.Context, vdi payloads.VDI, vmUUID uu
 	vbdID, err := c.VBD().Create(ctx, &payloads.CreateVBDParams{
 		VM:   vmUUID,
 		VDI:  vdi.ID,
-		Mode: payloads.VBDModeRW, // TODO: change it if "ReadOnly" is required
+		Mode: payloads.VBDModeRW,
 	})
 	if err != nil {
 		klog.ErrorS(err, "Failed to create VBD to attach VDI to the node", "vdi", vdi, "vmUUID", vmUUID)


### PR DESCRIPTION
# Pull Request

* Added support for configuring the CSI driver using environment variables as an alternative to config files, including documentation and manifest examples (`docs/install.md`, `README.md`, `pkg/xenorchestra-csi/xenorchestra-csi.go`, `deploy/csi-xenorchestra-node-single.yaml`, `deploy/csi-xenorchestra-controller-dev.yaml`).

Deployment reliability:

* Changed the deployment strategy for both controller and node manifests to `Recreate` for safer rolling updates (`deploy/csi-xenorchestra-controller-dev.yaml`, `deploy/csi-xenorchestra-node-single.yaml`).

Build and code cleanups:

* Improved Docker build caching for Go modules and build artifacts in `Dockerfile` to speed up builds and reduce resource usage.
* Minor code cleanups in `controllerserver.go` and `xoclient.go` for clarity and correctness.