### PR TITLE
feat: improve node metadata handling for CCM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A Container Storage Interface (CSI) driver that provides persistent storage for 
 This repository hosts the CSI driver and all of its build and dependent configuration files to deploy the driver.
 
 It is recommended to install the Xen Orchestra CCM in addition to the CSI driver.
+Without the CCM, topology labels are absent from nodes and Kubernetes cannot enforce
+pool-scoped volume placement (see [Topology and Placement](docs/topology.md)).
 
 * csi plugin name: `csi.xenorchestra.vates.tech`
 * supported accessModes: `ReadWriteOnce`
@@ -27,6 +29,7 @@ It is recommended to install the Xen Orchestra CCM in addition to the CSI driver
 ## Documentation
 
 - [Installation guide](docs/install.md) – requirements, credentials, StorageClass, static provisioning.
+- [Topology and Placement](docs/topology.md) – pool boundary, live migration behaviour, CCM dependency.
 - [Developer guide](docs/development.md) – build, `kxo` helper, DevSpace, MicroK8s registry, remote debugging.
 
 ## Install driver on a Kubernetes cluster
@@ -96,7 +99,7 @@ Name | Meaning | Example | Required | Default
 - [ ] Access modes - Add ReadWriteMany and ReadOnlyMany support
 
 ### Security & Configuration
-- [ ] Use with Xen Orchestra Cloud Controller Manager
+- [x] Use with Xen Orchestra Cloud Controller Manager
 - [x] Alternative for credential management (environment variables supported)
 - [ ] Check RBAC policies
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ A Container Storage Interface (CSI) driver that provides persistent storage for 
 
 This repository hosts the CSI driver and all of its build and dependent configuration files to deploy the driver.
 
-It is recommended to install the Xen Orchestra CCM in addition to the CSI driver.
-Without the CCM, topology labels are absent from nodes and Kubernetes cannot enforce
-pool-scoped volume placement (see [Topology and Placement](docs/topology.md)).
+The Xen Orchestra CCM is **required** when using the default
+`--node-metadata-source=kubernetes` mode. Without it, `spec.providerID` is not set
+on Node objects, `NodeGetInfo` fails, and the node-driver-registrar enters
+**CrashLoopBackOff** — the CSI node plugin never registers with kubelet and no
+volume operations are possible on that node. Use `--node-metadata-source=xo-api` if
+you cannot run the CCM (see [Topology and Placement](docs/topology.md)).
 
 * csi plugin name: `csi.xenorchestra.vates.tech`
 * supported accessModes: `ReadWriteOnce`

--- a/deploy/csi-xenorchestra-node-single.yaml
+++ b/deploy/csi-xenorchestra-node-single.yaml
@@ -82,6 +82,10 @@ spec:
             - "--endpoint=unix:///csi/csi.sock"
             - "--node-name=$(KUBE_NODE_NAME)"
             - "--config-file=/etc/xenorchestra/config.yaml"
+            # node-metadata-source controls how the pool ID and VM identity are resolved.
+            # kubernetes (default): reads from node labels set by the XenOrchestra CCM.
+            # xo-api: queries the XenOrchestra API directly; use when CCM is not installed.
+            - "--node-metadata-source=kubernetes"
           ports:
             - containerPort: 29603
               name: healthz

--- a/deploy/csi-xenorchestra-node.yaml
+++ b/deploy/csi-xenorchestra-node.yaml
@@ -81,6 +81,10 @@ spec:
             - "--endpoint=unix:///csi/csi.sock"
             - "--node-name=$(KUBE_NODE_NAME)"
             - "--config-file=/etc/xenorchestra/config.yaml"
+            # node-metadata-source controls how the pool ID and VM identity are resolved.
+            # kubernetes (default): reads from node labels set by the XenOrchestra CCM.
+            # xo-api: queries the XenOrchestra API directly; use when CCM is not installed.
+            - "--node-metadata-source=kubernetes"
           ports:
             - containerPort: 29603
               name: healthz

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,18 +25,21 @@ Network connectivity is required between every Kubernetes node and the Xen Orche
 
 ### XenOrchestra Cloud Controller Manager (CCM)
 
-The CCM is **strongly recommended** when using the CSI driver with the default
-`NodeMetadataFromKubernetes` mode. It sets the topology labels
-(e.g. `topology.k8s.xenorchestra/pool_id`) on each Kubernetes Node. The CSI driver
-reads these labels to build the `AccessibleTopology` that Kubernetes uses to
-schedule pods and volumes on the correct pool.
+The CCM is **required** when using the CSI driver with the default
+`--node-metadata-source=kubernetes` mode. The CCM sets `spec.providerID` on each
+Kubernetes Node object. The CSI node plugin reads this field at startup to resolve
+the pool ID and VM UUID, then returns them from `NodeGetInfo` so that kubelet can
+register the driver and write the `topology.k8s.xenorchestra/pool_id` label.
 
-TODO: Check that behavior (pool topology label will be absent on nodes)
+**Without the CCM**, `spec.providerID` is empty. `NodeGetInfo` fails with a
+`codes.Internal` error and the node-driver-registrar enters **CrashLoopBackOff**.
+The CSI node plugin is never registered with kubelet on that node: no volume can be
+staged, published, or unpublished. The `topology.k8s.xenorchestra/pool_id` label is
+never written to the Node object.
 
-**Without the CCM**, the pool topology label will be absent on nodes. Kubernetes
-will not enforce any placement constraints, and volume attachment can fail with a
-`FailedPrecondition` error when the scheduler picks a node in a different pool than
-the one owning the VDI.
+If you cannot run the CCM, use `--node-metadata-source=xo-api` instead — the driver
+will resolve the pool ID directly from the XenOrchestra API without depending on
+`spec.providerID`.
 
 The CSI driver reuses the same credentials secret as the CCM. If the CCM is already
 installed you can skip the [credentials step](#2-create-the-credentials-secret)

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,14 +23,28 @@ Network connectivity is required between every Kubernetes node and the Xen Orche
 - `kubectl` configured with access to the target cluster.
 - Sufficient RBAC permissions to create resources in the `kube-system` namespace.
 
-### Optional: XenOrchestra Cloud Controller Manager (CCM)
+### XenOrchestra Cloud Controller Manager (CCM)
 
-The CSI driver reuses the same credentials secret as the CCM.
-If the CCM is already installed in your cluster the secret is already present and you can skip the
-[credentials step](#2-create-the-credentials-secret) below.
+The CCM is **strongly recommended** when using the CSI driver with the default
+`NodeMetadataFromKubernetes` mode. It sets the topology labels
+(e.g. `topology.k8s.xenorchestra/pool_id`) on each Kubernetes Node. The CSI driver
+reads these labels to build the `AccessibleTopology` that Kubernetes uses to
+schedule pods and volumes on the correct pool.
+
+TODO: Check that behavior (pool topology label will be absent on nodes)
+
+**Without the CCM**, the pool topology label will be absent on nodes. Kubernetes
+will not enforce any placement constraints, and volume attachment can fail with a
+`FailedPrecondition` error when the scheduler picks a node in a different pool than
+the one owning the VDI.
+
+The CSI driver reuses the same credentials secret as the CCM. If the CCM is already
+installed you can skip the [credentials step](#2-create-the-credentials-secret)
+below.
 
 See the [CCM install guide](https://github.com/vatesfr/xenorchestra-cloud-controller-manager/blob/main/docs/install.md)
-for details.
+for setup instructions, and [docs/topology.md](topology.md) for a detailed
+explanation of how topology works in this driver.
 
 ---
 

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -1,0 +1,137 @@
+# Topology and Placement
+
+This document explains how the XenOrchestra CSI driver models cluster topology,
+why specific design decisions were made, and what their operational implications
+are.
+
+## How CSI topology works in Kubernetes
+
+When the CSI node plugin starts on a node it calls `NodeGetInfo`, which returns an
+`AccessibleTopology` map. Kubernetes stores these key/value pairs as labels on the
+Node object and uses them to enforce two placement rules:
+
+1. **Volume scheduling** — When a PVC with `volumeBindingMode: WaitForFirstConsumer`
+   is created, the scheduler picks a node first, then passes the node's topology to
+   `CreateVolume` so the driver can provision the volume in a location that is
+   reachable from that node.
+2. **PV node affinity** — Static PVs can carry a `nodeAffinity` rule based on
+   topology keys. Kubernetes will only schedule pods that mount that PV onto nodes
+   whose labels match.
+
+The labels are written by the **CSI node-driver-registrar (NDR)** sidecar. The NDR
+includes a collision-detection mechanism: if the value reported by `NodeGetInfo`
+differs from a label already present on the Node object the NDR times out and
+crash-loops the pod, preventing silent topology drift.
+
+## Topology segments used by this driver
+
+| Label key | Value | Set by |
+| --------- | ----- | ------ |
+| `topology.k8s.xenorchestra/pool_id` | XenOrchestra pool UUID | CCM or XoClient |
+
+### Why only pool_id
+
+A VDI (Virtual Disk Image) in XenOrchestra lives inside a Storage Repository (SR).
+An SR belongs to a pool. XenOrchestra **enforces at the API level** that a VDI can
+only be attached to a VM in the same pool — cross-pool attachment is forbidden.
+
+The pool ID is therefore the only segment that maps to a real access boundary.
+
+### Why host_id is intentionally absent
+
+An earlier version of this driver also included `topology.k8s.xenorchestra/host_id`
+in `AccessibleTopology`. This segment was removed for the following reasons:
+
+- **Live migration** — A VM can be migrated between hypervisors within the same pool
+  transparently and at any time. After migration the node's host label changes, but
+  the label that the NDR wrote before migration remains on the Node object. The NDR
+  detects the mismatch and crash-loops the CSI node pod, producing:
+
+  ```
+  detected topology value collision: driver reported
+  "topology.k8s.xenorchestra/host_id":"<new-uuid>"
+  but existing label is
+  "topology.k8s.xenorchestra/host_id":"<old-uuid>"
+  ```
+
+- **Shared SRs** — Most production SR types (NFS, iSCSI, Fibre Channel, Ceph…) are
+  shared across all hosts in the pool. Any VM in the pool can attach the VDI
+  regardless of which hypervisor it runs on. Constraining scheduling to a specific
+  host is not only unnecessary but actively harmful for workload distribution.
+
+- **Local SRs** — For SRs local to a single host (raw `lvm`, `ext`, `btrfs`…) host
+  affinity is meaningful. However this use case requires a more nuanced mechanism
+  (dynamic SR topology via the CCM, not a static value in `NodeGetInfo`) and is not
+  yet implemented.
+
+## Cross-pool migration restriction
+
+Moving a VM to a **different XenOrchestra pool** (cross-pool migration) is a
+disruptive operation that requires:
+
+1. Detaching all persistent volumes from the node.
+2. Migrating the VM and its storage.
+3. Re-attaching volumes in the new pool — which requires new PVs because the VDIs
+   are now in a different pool.
+
+This is not a transparent live event. Kubernetes treats it as a node replacement,
+following the same procedure as decommissioning a node. The `pool_id` topology
+segment therefore remains stable for the entire lifetime of a Kubernetes node
+under normal operating conditions.
+
+## Dependency on the XenOrchestra Cloud Controller Manager (CCM)
+
+### What the CCM does
+
+The [XenOrchestra Cloud Controller Manager](https://github.com/vatesfr/xenorchestra-cloud-controller-manager)
+runs in the cluster and continuously reconciles Kubernetes Node objects with the
+state in XenOrchestra. Among other things it sets the topology labels:
+
+```
+topology.k8s.xenorchestra/pool_id      = <uuid>
+topology.k8s.xenorchestra/host_id      = <uuid>
+topology.k8s.xenorchestra/pool_name_label = <name>
+topology.k8s.xenorchestra/host_name_label = <name>
+```
+
+### Is the CCM mandatory?
+
+The answer depends on which `--node-metadata-source` mode is configured for the
+node plugin. The flag is set in the node DaemonSet arguments.
+
+| `--node-metadata-source` | CCM required? | How pool_id is resolved |
+| ------------------------ | ------------- | ----------------------- |
+| `kubernetes` **(default)** | **Yes** | Reads the Xenorchestra topology labels and the `ProviderID` set by the CCM on the Node object. If they are absent the pool ID will be empty and topology is not enforced. |
+| `xo-api` | No | Queries the XenOrchestra API directly at startup to resolve the pool ID and VM UUID from the node name. |
+
+#### Choosing the right mode
+
+```
+--node-metadata-source=kubernetes   # recommended when CCM is running
+--node-metadata-source=xo-api       # use this when CCM is not installed
+```
+
+When using **`NodeMetadataFromKubernetes`** without the CCM, two things happen:
+
+TODO: Check this behavior 
+
+1. The `pool_id` topology segment is empty.
+2. Kubernetes imposes no topology constraints: pods can be scheduled on any node and
+   volumes can be attached across pool boundaries — which XenOrchestra will reject,
+   causing `ControllerPublishVolume` to fail with `FailedPrecondition`.
+
+**Running the CCM alongside the CSI driver is therefore strongly recommended.**
+It ensures that the pool topology is always present on Kubernetes nodes,
+that volumes are scheduled only on nodes that can access them, and that
+diagnostic labels (host, pool names) are kept up to date automatically.
+
+### CCM and live migration
+
+When a VM is live-migrated to another host, the CCM updates the informational
+`host_id` and `host_name_label` labels on the Node object. Because these labels are
+**not** reported by `NodeGetInfo` they are outside the NDR's collision detection
+scope and can be updated freely without affecting the CSI node pod.
+
+This is the correct separation of concerns:
+- **NDR / CSI topology** — immutable pool boundary.
+- **CCM labels** — live, informational node metadata that can change at any time.

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -101,7 +101,7 @@ node plugin. The flag is set in the node DaemonSet arguments.
 
 | `--node-metadata-source` | CCM required? | How pool_id is resolved |
 | ------------------------ | ------------- | ----------------------- |
-| `kubernetes` **(default)** | **Yes** | Reads the Xenorchestra topology labels and the `ProviderID` set by the CCM on the Node object. If they are absent the pool ID will be empty and topology is not enforced. |
+| `kubernetes` **(default)** | **Yes** | Reads the `ProviderID` set by the CCM on the Node object. If it is absent, `NodeGetInfo` fails and the node plugin cannot register with kubelet. |
 | `xo-api` | No | Queries the XenOrchestra API directly at startup to resolve the pool ID and VM UUID from the node name. |
 
 #### Choosing the right mode
@@ -111,14 +111,25 @@ node plugin. The flag is set in the node DaemonSet arguments.
 --node-metadata-source=xo-api       # use this when CCM is not installed
 ```
 
-When using **`NodeMetadataFromKubernetes`** without the CCM, two things happen:
+When using **`NodeMetadataFromKubernetes`** without the CCM, `spec.providerID` on the
+Node object is empty. `GetNodeMetadata()` calls `ParseProviderID("")`, which returns
+an error. `NodeGetInfo` propagates it as a `codes.Internal` gRPC error:
 
-TODO: Check this behavior 
+```
+failed to fetch node metadata: failed to parse provider ID:
+has the Xen Orchestra CCM been installed? (foreign providerID or empty "")
+```
 
-1. The `pool_id` topology segment is empty.
-2. Kubernetes imposes no topology constraints: pods can be scheduled on any node and
-   volumes can be attached across pool boundaries — which XenOrchestra will reject,
-   causing `ControllerPublishVolume` to fail with `FailedPrecondition`.
+The node-driver-registrar (NDR) receives this error via `NotifyRegistrationStatus`
+and immediately restarts, entering a **CrashLoopBackOff**. Consequences:
+
+1. **The CSI node plugin is never registered with kubelet** on that node.
+2. **No `topology.k8s.xenorchestra/pool_id` label is ever written** to the Node object.
+3. **No volume can be staged, published, or unpublished** on that node — the kubelet
+   has no registered driver to call.
+
+This is more severe than unenforced topology: the entire node plugin is non-functional
+until a CCM populates `spec.providerID`.
 
 **Running the CCM alongside the CSI driver is therefore strongly recommended.**
 It ensures that the pool topology is always present on Kubernetes nodes,

--- a/pkg/xenorchestra-csi/driveroptions.go
+++ b/pkg/xenorchestra-csi/driveroptions.go
@@ -17,6 +17,22 @@ package xenorchestracsi
 
 import (
 	"flag"
+	"fmt"
+)
+
+// NodeMetadataSource controls how the CSI node plugin resolves pool ID and VM
+// identity at startup. See docs/topology.md for details.
+type NodeMetadataSource string
+
+const (
+	// NodeMetadataSourceKubernetes reads the pool ID from the node label set by the
+	// XenOrchestra CCM (topology.k8s.xenorchestra/pool_id) and the VM UUID from the
+	// node's ProviderID. This is the recommended mode when the CCM is installed.
+	NodeMetadataSourceKubernetes NodeMetadataSource = "kubernetes"
+
+	// NodeMetadataSourceXoAPI queries the XenOrchestra API directly at startup to
+	// resolve the pool ID and VM UUID. Use this mode when the CCM is not installed.
+	NodeMetadataSourceXoAPI NodeMetadataSource = "xo-api"
 )
 
 // DriverOptions defines driver parameters specified in driver deployment
@@ -27,6 +43,8 @@ type DriverOptions struct {
 	Endpoint   string
 	// XO Configuration
 	ConfigFile string
+	// NodeMetadataSource selects how the node plugin resolves pool ID and VM identity.
+	NodeMetadataSource NodeMetadataSource
 }
 
 func (o *DriverOptions) AddFlags() *flag.FlagSet {
@@ -38,5 +56,24 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.StringVar(&o.DriverName, "driver-name", DriverName, "Driver name")
 	fs.StringVar(&o.Endpoint, "endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	fs.StringVar(&o.ConfigFile, "config-file", "/etc/xenorchestra/config.yaml", "Path to XO configuration file")
+	fs.Func("node-metadata-source",
+		`Source used by the node plugin to resolve pool ID and VM identity.
+Allowed values:
+  kubernetes  (default) Read pool ID from the node label set by the XenOrchestra CCM.
+              Requires the CCM to be installed and running in the cluster.
+  xo-api      Query the XenOrchestra API directly at startup.
+              Use this mode when the CCM is not installed.`,
+		func(v string) error {
+			src := NodeMetadataSource(v)
+			switch src {
+			case NodeMetadataSourceKubernetes, NodeMetadataSourceXoAPI:
+				o.NodeMetadataSource = src
+				return nil
+			default:
+				return fmt.Errorf("invalid node-metadata-source %q: must be %q or %q",
+					v, NodeMetadataSourceKubernetes, NodeMetadataSourceXoAPI)
+			}
+		},
+	)
 	return fs
 }

--- a/pkg/xenorchestra-csi/node_metadata.go
+++ b/pkg/xenorchestra-csi/node_metadata.go
@@ -54,7 +54,7 @@ func (n *NodeMetadataFromKubernetes) GetNodeMetadata() (*NodeMetadata, error) {
 
 	vm, poolId, err := xok8s.ParseProviderID(node.Spec.ProviderID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse provider ID: %w", err)
+		return nil, fmt.Errorf("failed to parse provider ID: has the Xen Orchestra CCM been installed? (%w)", err)
 	}
 
 	return &NodeMetadata{

--- a/pkg/xenorchestra-csi/node_metadata.go
+++ b/pkg/xenorchestra-csi/node_metadata.go
@@ -17,8 +17,6 @@ package xenorchestracsi
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
 	xok8s "github.com/vatesfr/xenorchestra-k8s-common"
 
@@ -32,7 +30,6 @@ type NodeMetadataGetter interface {
 
 type NodeMetadata struct {
 	NodeId string
-	HostId string
 	PoolId string
 }
 
@@ -48,44 +45,22 @@ func NewNodeMetadataFromKubernetes(client kclient.Interface, nodeName string) *N
 	}
 }
 
-// TODO: rework this part to use only CCM labels and not rely on DMI product UUID
+// GetNodeMetadata retrieves node identity and topology metadata from Kubernetes.
 func (n *NodeMetadataFromKubernetes) GetNodeMetadata() (*NodeMetadata, error) {
-	nodeId, err := getNodeIdFromDmiProductUUID()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node id: %w", err)
-	}
-
 	node, err := n.client.CoreV1().Nodes().Get(context.Background(), n.nodeName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node: %w", err)
 	}
 
-	hostId := node.Labels[xok8s.XOLabelTopologyHostID]
-	poolId := node.Labels[xok8s.XOLabelTopologyPoolID]
+	vm, poolId, err := xok8s.ParseProviderID(node.Spec.ProviderID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse provider ID: %w", err)
+	}
 
 	return &NodeMetadata{
-		NodeId: nodeId,
-		HostId: hostId,
-		PoolId: poolId,
+		NodeId: vm.ID.String(),
+		PoolId: poolId.String(),
 	}, nil
-}
-
-// This should give us the VM UUID as reported in Xen Orchestra
-// We are using `/sys/class/dmi/id/product_uuid`. However, I am not sure if there are more reliable ways to get the VM UUID.
-// Another option is to use `xenstore-ls`
-// There is also `/sys/hypervisor/uuid` but it's not clear if that's the same as the VM UUID
-func getNodeIdFromDmiProductUUID() (string, error) {
-	productUUID, err := os.ReadFile("/sys/class/dmi/id/product_uuid")
-	if err != nil {
-		return "", fmt.Errorf("failed to read product UUID: %w", err)
-	}
-
-	uuid := strings.TrimSpace(string(productUUID))
-	if uuid == "" {
-		return "", fmt.Errorf("failed to get product UUID: product UUID is empty")
-	}
-
-	return uuid, nil
 }
 
 // NodeMetadataFromXoClient uses the XoClient to get all needed metadata.
@@ -103,6 +78,9 @@ func NewNodeMetadataFromXoClient(kubeClient kclient.Interface, xoClient *xok8s.X
 	}
 }
 
+// GetNodeMetadata retrieves node identity and topology metadata directly from
+// the XenOrchestra API. This implementation does not depend on the CCM having
+// labeled the node beforehand; it resolves the pool ID by querying XO at startup.
 func (n *NodeMetadataFromXoClient) GetNodeMetadata() (*NodeMetadata, error) {
 	node, err := n.kclient.CoreV1().Nodes().Get(context.Background(), n.nodeName, metav1.GetOptions{})
 	if err != nil {
@@ -112,9 +90,9 @@ func (n *NodeMetadataFromXoClient) GetNodeMetadata() (*NodeMetadata, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to find VM by node: %w", err)
 	}
+
 	return &NodeMetadata{
 		NodeId: vm.ID.String(),
-		HostId: vm.Container.String(),
 		PoolId: poolID.String(),
 	}, nil
 }

--- a/pkg/xenorchestra-csi/nodeserver.go
+++ b/pkg/xenorchestra-csi/nodeserver.go
@@ -56,10 +56,12 @@ func (driver *xenorchestraCSIDriver) NodeGetInfo(ctx context.Context, req *csi.N
 	}
 	return &csi.NodeGetInfoResponse{
 		NodeId: metadata.NodeId,
+		// According to Xen Orchestra documentation, 241 is the maximum number of VDIs that can be attached to a single VM,
+		// but we reserve 2 for the root disk and CD-ROM.
+		MaxVolumesPerNode: 239,
 		AccessibleTopology: &csi.Topology{
 			Segments: map[string]string{
 				xok8s.XOLabelTopologyPoolID: metadata.PoolId,
-				xok8s.XOLabelTopologyHostID: metadata.HostId,
 			},
 		},
 	}, nil

--- a/pkg/xenorchestra-csi/xenorchestra-csi.go
+++ b/pkg/xenorchestra-csi/xenorchestra-csi.go
@@ -86,8 +86,24 @@ func NewDriver(options *DriverOptions) Driver {
 		klog.Fatalf("failed to create Xen Orchestra client: %v", err)
 	}
 
-	// TODO: make it configurable to use the CCM labels or the NodeMetadata (no CCM dependency)
-	nodeMetadataGetter := NewNodeMetadataFromXoClient(kclient, xoClient, options.NodeName)
+	// Select the NodeMetadata implementation based on the configured source.
+	// - NodeMetadataSourceKubernetes (default): reads pool ID from the node label
+	//   topology.k8s.xenorchestra/pool_id set by the XenOrchestra CCM.
+	// - NodeMetadataSourceXoAPI: queries the XenOrchestra API directly at startup;
+	//   use this when the Xen Orchestra CCM is not installed.
+	var nodeMetadataGetter NodeMetadataGetter
+	switch options.NodeMetadataSource {
+	case NodeMetadataSourceXoAPI:
+		klog.Info("Node metadata source: xo-api (CCM not required)")
+		nodeMetadataGetter = NewNodeMetadataFromXoClient(kclient, xoClient, options.NodeName)
+	default:
+		// NodeMetadataSourceKubernetes is the default.
+		if options.NodeMetadataSource != NodeMetadataSourceKubernetes {
+			klog.Warningf("Unknown node-metadata-source %q, falling back to %q", options.NodeMetadataSource, NodeMetadataSourceKubernetes)
+		}
+		klog.Info("Node metadata source: kubernetes (requires the XenOrchestra CCM)")
+		nodeMetadataGetter = NewNodeMetadataFromKubernetes(kclient, options.NodeName)
+	}
 
 	klog.Infof("Driver: %v ", options.DriverName)
 	klog.Infof("Version: %s", driverVersion)

--- a/pkg/xenorchestra-csi/xenorchestra-csi.go
+++ b/pkg/xenorchestra-csi/xenorchestra-csi.go
@@ -99,7 +99,7 @@ func NewDriver(options *DriverOptions) Driver {
 	default:
 		// NodeMetadataSourceKubernetes is the default.
 		if options.NodeMetadataSource != NodeMetadataSourceKubernetes {
-			klog.Warningf("Unknown node-metadata-source %q, falling back to %q", options.NodeMetadataSource, NodeMetadataSourceKubernetes)
+			klog.Fatalf("Unknown node-metadata-source %q", options.NodeMetadataSource)
 		}
 		klog.Info("Node metadata source: kubernetes (requires the XenOrchestra CCM)")
 		nodeMetadataGetter = NewNodeMetadataFromKubernetes(kclient, options.NodeName)


### PR DESCRIPTION
# Pull Request

## What? (description)

* Clarify the labeling done by the CSI and the use of the CCM.
* Add flag the `NodeGetInfo()` source to choose between using the labels set by the CCM (`--node-metadata-source=kubernetes`) or using the Xen Orchestra API (`--node-metadata-source=xo-api`) 
* Remove `host_id` label that was set by the CSI: A VM can be migrated between hypervisors within the same pool transparently and at any time. After migration the node's host label changes, but the label that the NDR wrote before migration remains on the Node object.

## Why? (reasoning)

With these changes, we can use labels set and updated by the CCM. Alternatively, we can use only the `pool_id` set by the CSI. Not more "topology value collision" due to NDR label detection mismatch.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
