### PR TITLE
Fix: SR connectivity check before VBD attach/connect

### DIFF
--- a/pkg/xenorchestra-csi/clients/mock/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/mock/xoclient.go
@@ -117,6 +117,20 @@ func (mr *MockXoClientMockRecorder) Host() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Host", reflect.TypeOf((*MockXoClient)(nil).Host))
 }
 
+// IsSRAttachedToVMHost mocks base method.
+func (m *MockXoClient) IsSRAttachedToVMHost(ctx context.Context, vbdID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSRAttachedToVMHost", ctx, vbdID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IsSRAttachedToVMHost indicates an expected call of IsSRAttachedToVMHost.
+func (mr *MockXoClientMockRecorder) IsSRAttachedToVMHost(ctx, vbdID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSRAttachedToVMHost", reflect.TypeOf((*MockXoClient)(nil).IsSRAttachedToVMHost), ctx, vbdID)
+}
+
 // IsVDIUsedAnywhere mocks base method.
 func (m *MockXoClient) IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI) ([]*payloads.VBD, error) {
 	m.ctrl.T.Helper()
@@ -130,6 +144,20 @@ func (m *MockXoClient) IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI)
 func (mr *MockXoClientMockRecorder) IsVDIUsedAnywhere(ctx, vdi any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVDIUsedAnywhere", reflect.TypeOf((*MockXoClient)(nil).IsVDIUsedAnywhere), ctx, vdi)
+}
+
+// IsSRAttachedToHost mocks base method.
+func (m *MockXoClient) IsSRAttachedToHost(ctx context.Context, srID uuid.UUID, hostID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSRAttachedToHost", ctx, srID, hostID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IsSRAttachedToHost indicates an expected call of IsSRAttachedToHost.
+func (mr *MockXoClientMockRecorder) IsSRAttachedToHost(ctx, srID, hostID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSRAttachedToHost", reflect.TypeOf((*MockXoClient)(nil).IsSRAttachedToHost), ctx, srID, hostID)
 }
 
 // PBD mocks base method.

--- a/pkg/xenorchestra-csi/clients/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/xoclient.go
@@ -44,6 +44,13 @@ type XoClient interface {
 	AttachVDIToVM(ctx context.Context, vdi payloads.VDI, vmUUID uuid.UUID) (*payloads.VBD, error)
 	WaitForVDIToBeFullyAttached(ctx context.Context, vbdID uuid.UUID) (*payloads.VBD, error)
 	IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI) ([]*payloads.VBD, error)
+	// IsSRAttachedToHost checks that the given SR is connected (via a plugged PBD) to the given host.
+	// Returns nil when the SR is reachable, or a descriptive error otherwise.
+	IsSRAttachedToHost(ctx context.Context, srID uuid.UUID, hostID uuid.UUID) error
+	// IsSRAttachedToVMHost checks that the SR backing the given VBD is connected (via a plugged PBD)
+	// to the XCP-ng host where the VBD's VM is currently running.
+	// Returns nil when the SR is reachable, or a descriptive error otherwise.
+	IsSRAttachedToVMHost(ctx context.Context, vbdID uuid.UUID) error
 }
 
 type xoClient struct {
@@ -156,6 +163,45 @@ func (c xoClient) IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI) ([]*
 	}
 
 	return vbds, nil
+}
+
+// IsSRAttachedToHost checks that the given SR is connected (via a plugged PBD) to the given host.
+func (c xoClient) IsSRAttachedToHost(ctx context.Context, srID uuid.UUID, hostID uuid.UUID) error {
+	pbds, err := c.PBD().GetAll(ctx, 1, fmt.Sprintf("SR:%s host:%s", srID, hostID))
+	if err != nil {
+		return fmt.Errorf("failed to list PBDs for SR %s on host %s: %w", srID, hostID, err)
+	}
+	if len(pbds) == 0 {
+		return fmt.Errorf("SR %s has no PBD for host %s; the SR may not be shared with this host", srID, hostID)
+	}
+	if !pbds[0].Attached {
+		return fmt.Errorf("SR %s is not connected to host %s (PBD %s is unplugged)", srID, hostID, pbds[0].ID)
+	}
+	return nil
+}
+
+// IsSRAttachedToVMHost checks that the SR backing the given VBD is connected (via a plugged PBD)
+// to the XCP-ng host where the VBD's VM is currently running.
+func (c xoClient) IsSRAttachedToVMHost(ctx context.Context, vbdID uuid.UUID) error {
+	vbd, err := c.VBD().Get(ctx, vbdID)
+	if err != nil {
+		return fmt.Errorf("failed to get VBD %s: %w", vbdID, err)
+	}
+	if vbd.VDI == nil {
+		return fmt.Errorf("VBD %s has no VDI", vbdID)
+	}
+
+	vm, err := c.VM().GetByID(ctx, vbd.VM)
+	if err != nil {
+		return fmt.Errorf("failed to get VM %s for VBD %s: %w", vbd.VM, vbdID, err)
+	}
+
+	vdi, err := c.VDI().Get(ctx, *vbd.VDI)
+	if err != nil {
+		return fmt.Errorf("failed to get VDI %s: %w", vbd.VDI, err)
+	}
+
+	return c.IsSRAttachedToHost(ctx, vdi.SR, vm.Container)
 }
 
 func (c xoClient) DisconnectVBDFromVM(ctx context.Context, vdi payloads.VDI, vmUUID uuid.UUID) error {

--- a/pkg/xenorchestra-csi/controllerserver.go
+++ b/pkg/xenorchestra-csi/controllerserver.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/vatesfr/xenorchestra-csi-driver/pkg/xenorchestra-csi/clients"
 	"github.com/vatesfr/xenorchestra-go-sdk/pkg/payloads"
+	xok8s "github.com/vatesfr/xenorchestra-k8s-common"
 
 	"k8s.io/klog/v2"
 )
@@ -134,6 +135,13 @@ func (driver *xenorchestraCSIDriver) ControllerPublishVolume(ctx context.Context
 		return nil, status.Errorf(codes.FailedPrecondition, "cannot attach VDI from pool %s to VM in pool %s", vdi.PoolID, nodeVM.PoolID)
 	}
 
+	// Verify the SR is reachable from the host where the VM is running before attempting
+	// to attach or connect any VBD.
+	if err := driver.xoClient.IsSRAttachedToHost(ctx, vdi.SR, nodeVM.Container); err != nil {
+		klog.ErrorS(err, "SR is not attached to VM host", "srID", vdi.SR, "hostID", nodeVM.Container, "vmUUID", vmUUID)
+		return nil, status.Errorf(codes.FailedPrecondition, "SR is not attached to the VM host: %v", err)
+	}
+
 	// Check the VDI is not already attached to another VM
 	vbds, err := driver.xoClient.IsVDIUsedAnywhere(ctx, vdi)
 	if err != nil {
@@ -167,6 +175,15 @@ func (driver *xenorchestraCSIDriver) ControllerPublishVolume(ctx context.Context
 				}, nil
 			}
 			klog.V(2).InfoS("VDI already attached to the node", "vbd", vbdToAttach)
+			if vbdToAttach.Device == nil {
+				klog.ErrorS(nil, "Device name is not yet assigned to the VBD, waiting...", "vbd", vbdToAttach)
+				vbdToAttach, err = driver.xoClient.WaitForVDIToBeFullyAttached(ctx, vbdToAttach.ID)
+				if err != nil {
+					klog.ErrorS(err, "Failed to wait for VBD to be fully attached", "vbd", vbdToAttach)
+					return nil, status.Errorf(codes.Internal, "Failed to wait for VBD to be fully attached: %v", err)
+				}
+				klog.V(5).InfoS("VBD is now fully attached with device name assigned", "vbd", vbdToAttach)
+			}
 			return &csi.ControllerPublishVolumeResponse{
 				PublishContext: publishContextFromVBD(*vbdToAttach),
 			}, nil
@@ -415,8 +432,8 @@ func (driver *xenorchestraCSIDriver) buildAccessibleTopology(pool *payloads.Pool
 	return []*csi.Topology{
 		{
 			Segments: map[string]string{
-				"pool": pool.ID.String(),
-				"sr":   pool.DefaultSR.String(),
+				xok8s.XOLabelTopologyPoolID:       pool.ID.String(),
+				"topology.k8s.xenorchestra/sr_id": pool.DefaultSR.String(),
 			},
 		},
 	}

--- a/pkg/xenorchestra-csi/nodeserver.go
+++ b/pkg/xenorchestra-csi/nodeserver.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/gofrs/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -233,6 +234,27 @@ func (driver *xenorchestraCSIDriver) NodeStageVolume(ctx context.Context, req *c
 	if currentDevice == device {
 		klog.V(2).Info("NodeStageVolume: volume already staged", "device", device, "target", stagingTarget)
 		return &csi.NodeStageVolumeResponse{}, nil
+	}
+
+	// Verify the SR backing this VBD is connected to the host where the VM is running.
+	// XenOrchestra may report a VDI as attached and provide a device name, but if the SR
+	// is not connected to the XCP-ng host the block device will not appear in /dev/.
+	vbdIDStr := req.GetPublishContext()["vbd"]
+	if vbdIDStr == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "vbd is not set in publish context")
+	}
+	vbdID, err := uuid.FromString(vbdIDStr)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "vbd in publish context is not a valid UUID: %v", err)
+	}
+	if err := driver.xoClient.IsSRAttachedToVMHost(ctx, vbdID); err != nil {
+		return nil, status.Errorf(codes.Internal, "SR connectivity check failed for VBD %s: %v", vbdIDStr, err)
+	}
+
+	// Verify the device actually exists on this host before attempting to format/mount.
+	if _, err := os.Stat(devicePath); os.IsNotExist(err) {
+		klog.ErrorS(err, "device does not exist on this host despite SR being connected", "devicePath", devicePath)
+		return nil, status.Errorf(codes.Internal, "device %s does not exist on this host despite SR being connected", devicePath)
 	}
 
 	// Format device if needed

--- a/test/sanity/fakedriver_test.go
+++ b/test/sanity/fakedriver_test.go
@@ -50,6 +50,7 @@ func NewFakeDriver(t *testing.T, options *xenorchestracsi.DriverOptions, fakeMou
 		Device: &device,
 	}, nil).AnyTimes()
 	mockXoClient.EXPECT().DisconnectVBDFromVM(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockXoClient.EXPECT().IsSRAttachedToHost(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	return xenorchestracsi.NewDriverWithDependencies(
 		options,


### PR DESCRIPTION
When a VDI is attached to a VM whose host does not have the VDI's Storage Repository connected, Xen Orchestra silently accepts the operation and assigns a device name to the VBD — as if everything succeeded. However, because the SR is not plugged on that host, the block device never actually appears on the VM.

This causes a confusing error during the NodeStageVolume step: the node server attempts to mount a device that does not exist, and the error surfaces as a mount failure rather than pointing to the real cause (the SR not being connected to the host).

This PR adds an SR connectivity check (via the host's PBD state) in two places:
- In ControllerPublishVolume, before attaching the VDI or connecting an existing VBD to the VM, ensuring the operation is rejected early with a clear FailedPrecondition error.
- In NodeStageVolume, as a secondary safeguard before attempting to format and mount the device.

This PR also fixes a bug where ControllerPublishVolume could return a publish context without a device name when the VBD was already attached to the VM but the device name had not yet been assigned. It now waits for the device name to be set before returning.
