### PR TITLE
refactor: introduce stable CSI volume ID and encapsulate VDI operations in XoClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ you cannot run the CCM (see [Topology and Placement](docs/topology.md)).
 
 ## Prerequisite
 
-* XenOrchestra version 5.110.1+
+* XenOrchestra version **6.4+**
 * XCP-ng version 8.3+
 * Network connectivity between Kubernetes nodes and XO API
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ you cannot run the CCM (see [Topology and Placement](docs/topology.md)).
 
 ## Documentation
 
+- [Documentation index](docs/README.md) – entry point to guides, migrations, and references.
 - [Installation guide](docs/install.md) – requirements, credentials, StorageClass, static and dynamic provisioning.
 - [Topology and Placement](docs/topology.md) – pool boundary, live migration behaviour, CCM dependency.
 - [Developer guide](docs/development.md) – build, `kxo` helper, DevSpace, MicroK8s registry, remote debugging.
+- [Migration v0.2.0 to v0.3.0](docs/migrations/v0.2.0-to-v0.3.0.md) – backfill `other-config:csi-volume-handle` on legacy VDIs.
+- [Reference: Volume Handle and Volume ID in v0.3.0](docs/references/volume-handle-and-volume-id-v0.3.0.md) – details about stable CSI identity semantics.
 
 ## Install driver on a Kubernetes cluster
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ you cannot run the CCM (see [Topology and Placement](docs/topology.md)).
 - [Installation guide](docs/install.md) – requirements, credentials, StorageClass, static and dynamic provisioning.
 - [Topology and Placement](docs/topology.md) – pool boundary, live migration behaviour, CCM dependency.
 - [Developer guide](docs/development.md) – build, `kxo` helper, DevSpace, MicroK8s registry, remote debugging.
-- [Migration v0.2.0 to v0.3.0](docs/migrations/v0.2.0-to-v0.3.0.md) – backfill `other-config:csi-volume-handle` on legacy VDIs.
+- [Migration v0.2.0 to v0.3.0](docs/migrations/v0.2.0-to-v0.3.0.md) – backfill `other-config:kubernetes_volume_id` on legacy VDIs.
 - [Reference: Volume Handle and Volume ID in v0.3.0](docs/references/volume-handle-and-volume-id-v0.3.0.md) – details about stable CSI identity semantics.
 
 ## Install driver on a Kubernetes cluster

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+## Documentation Index
+
+This folder is organized by purpose:
+- guides: evergreen operational and development documentation,
+- migrations: version-to-version upgrade procedures,
+- references: version-specific technical behavior and concepts.
+
+## Current guides
+
+- [Installation guide](install.md)
+- [Topology and Placement](topology.md)
+- [Developer guide](development.md)
+
+## Migrations
+
+- [v0.2.0 to v0.3.0](migrations/v0.2.0-to-v0.3.0.md)
+
+## References
+
+- [Volume Handle and Volume ID in v0.3.0](references/volume-handle-and-volume-id-v0.3.0.md)

--- a/docs/migrations/v0.2.0-to-v0.3.0.md
+++ b/docs/migrations/v0.2.0-to-v0.3.0.md
@@ -3,16 +3,19 @@
 ## Summary
 
 v0.3.0 introduces a stable CSI volume identity stored in VDI metadata:
-- other-config:csi-volume-handle
+- other-config:kubernetes_volume_id
 
 For volumes created in v0.2.0, a one-time metadata backfill is required.
 
-The migration action is:
-- set other-config:csi-volume-handle to the current VDI UUID.
+The migration actions are:
+- set other-config:kubernetes_volume_id to the current VDI UUID.
+- rename other-config:kubernetesPVName to other-config:kubernetes_pv_name.
 
 ## Why migration is needed
 
-Legacy volumes do not contain csi-volume-handle by default.
+Legacy volumes do not contain kubernetes_volume_id by default.
+In addition, volumes created in v0.2.0 store the PV name under the key
+`kubernetesPVName`, which has been renamed to `kubernetes_pv_name` in v0.3.0.
 
 After upgrading, adding this key ensures a consistent identity model for both:
 - previously provisioned volumes,
@@ -35,13 +38,13 @@ xe vdi-param-get uuid=<VDI_UUID> param-name=other-config
 ### 2. Backfill the stable CSI volume key
 
 ```bash
-xe vdi-param-set uuid=<VDI_UUID> other-config:csi-volume-handle=<VDI_UUID>
+xe vdi-param-set uuid=<VDI_UUID> other-config:kubernetes_volume_id=<VDI_UUID>
 ```
 
 Example:
 
 ```bash
-xe vdi-param-set uuid=3ceb6f8c-4226-4133-92f6-52ec7be8cc4d other-config:csi-volume-handle=3ceb6f8c-4226-4133-92f6-52ec7be8cc4d
+xe vdi-param-set uuid=3ceb6f8c-4226-4133-92f6-52ec7be8cc4d other-config:kubernetes_volume_id=3ceb6f8c-4226-4133-92f6-52ec7be8cc4d
 ```
 
 ### 3. Verify
@@ -51,7 +54,43 @@ xe vdi-param-get uuid=<VDI_UUID> param-name=other-config
 ```
 
 Expected result includes:
-- csi-volume-handle: <VDI_UUID>
+- kubernetes_volume_id: <VDI_UUID>
+
+## Rename kubernetesPVName to kubernetes_pv_name
+
+v0.3.0 renames the PV name metadata key from `kubernetesPVName` to
+`kubernetes_pv_name` for consistency. Volumes created in v0.2.0 must have
+this key renamed.
+
+### 1. Read the current PV name value
+
+```bash
+xe vdi-param-get uuid=<VDI_UUID> param-name=other-config
+```
+
+Locate the value of `kubernetesPVName` in the output.
+
+### 2. Write the new key and remove the old one
+
+```bash
+xe vdi-param-set uuid=<VDI_UUID> other-config:kubernetes_pv_name=<PV_NAME>
+xe vdi-param-remove uuid=<VDI_UUID> param-name=other-config param-key=kubernetesPVName
+```
+
+Example:
+
+```bash
+xe vdi-param-set uuid=3ceb6f8c-4226-4133-92f6-52ec7be8cc4d other-config:kubernetes_pv_name=pvc-abc123
+xe vdi-param-remove uuid=3ceb6f8c-4226-4133-92f6-52ec7be8cc4d param-name=other-config param-key=kubernetesPVName
+```
+
+### 3. Verify
+
+```bash
+xe vdi-param-get uuid=<VDI_UUID> param-name=other-config
+```
+
+Expected result includes `kubernetes_pv_name` and no longer contains `kubernetesPVName`.
 
 ## Rollback and safety
 
@@ -60,8 +99,11 @@ This migration is metadata-only and additive.
 If required, remove the key with:
 
 ```bash
-xe vdi-param-remove uuid=<VDI_UUID> param-name=other-config param-key=csi-volume-handle
+xe vdi-param-remove uuid=<VDI_UUID> param-name=other-config param-key=kubernetes_volume_id
 ```
+
+For the PV name key rename, the old `kubernetesPVName` key can be re-added and
+`kubernetes_pv_name` removed if a rollback is needed.
 
 Do not modify unrelated keys unless required by your operational workflow
 (example: content_id).
@@ -69,4 +111,5 @@ Do not modify unrelated keys unless required by your operational workflow
 ## Post-migration checks
 
 - Confirm migrated PVs can still be attached and mounted.
-- Validate new volumes provisioned after upgrade include csi-volume-handle.
+- Validate new volumes provisioned after upgrade include kubernetes_volume_id.
+- Validate that volumes have kubernetes_pv_name and no longer have kubernetesPVName.

--- a/docs/migrations/v0.2.0-to-v0.3.0.md
+++ b/docs/migrations/v0.2.0-to-v0.3.0.md
@@ -1,0 +1,72 @@
+## Migration Guide v0.2.0 to v0.3.0
+
+## Summary
+
+v0.3.0 introduces a stable CSI volume identity stored in VDI metadata:
+- other-config:csi-volume-handle
+
+For volumes created in v0.2.0, a one-time metadata backfill is required.
+
+The migration action is:
+- set other-config:csi-volume-handle to the current VDI UUID.
+
+## Why migration is needed
+
+Legacy volumes do not contain csi-volume-handle by default.
+
+After upgrading, adding this key ensures a consistent identity model for both:
+- previously provisioned volumes,
+- and newly created v0.3.0 volumes.
+
+## Prerequisites
+
+- Access to an XCP-ng host with xe CLI privileges.
+- The list of VDI UUIDs used by existing Kubernetes PersistentVolumes.
+- A maintenance window is recommended for controlled rollout.
+
+## Single-volume migration
+
+### 1. Inspect current metadata
+
+```bash
+xe vdi-param-get uuid=<VDI_UUID> param-name=other-config
+```
+
+### 2. Backfill the stable CSI volume key
+
+```bash
+xe vdi-param-set uuid=<VDI_UUID> other-config:csi-volume-handle=<VDI_UUID>
+```
+
+Example:
+
+```bash
+xe vdi-param-set uuid=3ceb6f8c-4226-4133-92f6-52ec7be8cc4d other-config:csi-volume-handle=3ceb6f8c-4226-4133-92f6-52ec7be8cc4d
+```
+
+### 3. Verify
+
+```bash
+xe vdi-param-get uuid=<VDI_UUID> param-name=other-config
+```
+
+Expected result includes:
+- csi-volume-handle: <VDI_UUID>
+
+## Rollback and safety
+
+This migration is metadata-only and additive.
+
+If required, remove the key with:
+
+```bash
+xe vdi-param-remove uuid=<VDI_UUID> param-name=other-config param-key=csi-volume-handle
+```
+
+Do not modify unrelated keys unless required by your operational workflow
+(example: content_id).
+
+## Post-migration checks
+
+- Confirm migrated PVs can still be attached and mounted.
+- Validate new volumes provisioned after upgrade include csi-volume-handle.

--- a/docs/references/volume-handle-and-volume-id-v0.3.0.md
+++ b/docs/references/volume-handle-and-volume-id-v0.3.0.md
@@ -1,0 +1,71 @@
+## Volume Handle and Volume ID in v0.3.0
+
+## Scope
+
+This reference explains the volume identity model introduced in v0.3.0 for
+xenorchestra-csi.
+
+For step-by-step upgrade actions, see the migration guide:
+[Migration v0.2.0 to v0.3.0](../migrations/v0.2.0-to-v0.3.0.md).
+
+## Terminology
+
+- VDI UUID: Xen Orchestra disk UUID backing a volume.
+- CSI volumeHandle: the stable identity Kubernetes stores in PersistentVolume.
+- CSI volume ID: internal value used by the driver for lookup and lifecycle
+  operations. In this driver, this is the same value exposed as volumeHandle.
+
+## Behavior in v0.2.0
+
+In v0.2.0, volume identity for existing operational paths was tied to the VDI
+UUID.
+
+This design works while the backend UUID remains unchanged, but it couples CSI
+identity to a storage-level identifier. The VDI UUID is not guaranteed to be
+stable: it changes when a VDI is migrated to another Storage Repository (SR),
+for example during a storage live migration or a manual VDI move between SRs.
+
+## Behavior in v0.3.0
+
+In v0.3.0, the driver uses a stable CSI volume ID stored in VDI metadata under:
+- other-config key: csi-volume-handle
+
+This key is represented in code by:
+- VDIOtherConfigKeyVolumeId = csi-volume-handle
+
+The objective is to decouple CSI identity from backend VDI UUID lifecycle.
+
+## Why this change
+
+A CSI volume identity should remain stable from Kubernetes point of view.
+
+Backend operations can change VDI UUID in some workflows (for example storage
+relocation patterns). If the CSI identity depends directly on that UUID,
+reconciliation and lookup become fragile.
+
+Using a dedicated metadata key makes the identity explicit and stable.
+
+## Practical implications
+
+- New volumes created with v0.3.0 get a dedicated CSI volume ID in
+  other-config:csi-volume-handle.
+- Legacy volumes created before v0.3.0 may not have this key.
+- Legacy volumes should be backfilled during migration so that operational
+  lookup remains consistent after upgrade.
+
+## Metadata key reference
+
+- Key: csi-volume-handle
+- Location: VDI other-config
+- Expected value:
+  - v0.3.0 native volumes: generated stable CSI volume ID,
+  - migrated legacy volumes: set to current VDI UUID as compatibility backfill.
+
+## Related keys
+
+Other keys commonly present in VDI other-config:
+- createdBy
+- kubernetesPVName
+
+These keys are informational and separate from the CSI stable volume identity
+key introduced for v0.3.0.

--- a/docs/references/volume-handle-and-volume-id-v0.3.0.md
+++ b/docs/references/volume-handle-and-volume-id-v0.3.0.md
@@ -28,10 +28,10 @@ for example during a storage live migration or a manual VDI move between SRs.
 ## Behavior in v0.3.0
 
 In v0.3.0, the driver uses a stable CSI volume ID stored in VDI metadata under:
-- other-config key: csi-volume-handle
+- other-config key: kubernetes_volume_id
 
 This key is represented in code by:
-- VDIOtherConfigKeyVolumeId = csi-volume-handle
+- VDIOtherConfigKeyVolumeId = kubernetes_volume_id
 
 The objective is to decouple CSI identity from backend VDI UUID lifecycle.
 
@@ -48,14 +48,14 @@ Using a dedicated metadata key makes the identity explicit and stable.
 ## Practical implications
 
 - New volumes created with v0.3.0 get a dedicated CSI volume ID in
-  other-config:csi-volume-handle.
+  other-config:kubernetes_volume_id.
 - Legacy volumes created before v0.3.0 may not have this key.
 - Legacy volumes should be backfilled during migration so that operational
   lookup remains consistent after upgrade.
 
 ## Metadata key reference
 
-- Key: csi-volume-handle
+- Key: kubernetes_volume_id
 - Location: VDI other-config
 - Expected value:
   - v0.3.0 native volumes: generated stable CSI volume ID,
@@ -64,8 +64,8 @@ Using a dedicated metadata key makes the identity explicit and stable.
 ## Related keys
 
 Other keys commonly present in VDI other-config:
-- createdBy
-- kubernetesPVName
+- kubernetes_created_by
+- kubernetes_pv_name
 
 These keys are informational and separate from the CSI stable volume identity
 key introduced for v0.3.0.

--- a/pkg/xenorchestra-csi/clients/constants.go
+++ b/pkg/xenorchestra-csi/clients/constants.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2025 Vates
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package clients
+
+// VDIOtherConfigKeyVolumeId is the XO VDI other_config key that stores the
+// CSI volume ID (UUID) generated at CreateVolume time.
+// This UUID is stable across SR migrations (VDI UUID changes, volume ID does not).
+const VDIOtherConfigKeyVolumeId = "csi-volume-handle"
+
+// VDIOtherConfigKeyCreatedBy is the key in VDI's other_config map that identifies
+// the component that created the VDI (always set to the driver name).
+const VDIOtherConfigKeyCreatedBy = "createdBy"
+
+// VDIOtherConfigKeyPVName is the key in VDI's other_config map that stores
+// the Kubernetes PersistentVolume name associated with this VDI.
+const VDIOtherConfigKeyPVName = "kubernetesPVName"

--- a/pkg/xenorchestra-csi/clients/constants.go
+++ b/pkg/xenorchestra-csi/clients/constants.go
@@ -18,12 +18,12 @@ package clients
 // VDIOtherConfigKeyVolumeId is the XO VDI other_config key that stores the
 // CSI volume ID (UUID) generated at CreateVolume time.
 // This UUID is stable across SR migrations (VDI UUID changes, volume ID does not).
-const VDIOtherConfigKeyVolumeId = "csi-volume-handle"
+const VDIOtherConfigKeyVolumeId = "kubernetes_volume_id"
 
 // VDIOtherConfigKeyCreatedBy is the key in VDI's other_config map that identifies
 // the component that created the VDI (always set to the driver name).
-const VDIOtherConfigKeyCreatedBy = "createdBy"
+const VDIOtherConfigKeyCreatedBy = "kubernetes_created_by"
 
 // VDIOtherConfigKeyPVName is the key in VDI's other_config map that stores
 // the Kubernetes PersistentVolume name associated with this VDI.
-const VDIOtherConfigKeyPVName = "kubernetesPVName"
+const VDIOtherConfigKeyPVName = "kubernetes_pv_name"

--- a/pkg/xenorchestra-csi/clients/errors.go
+++ b/pkg/xenorchestra-csi/clients/errors.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2025 Vates
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package clients
+
+import "errors"
+
+// ErrVBDNotFound is returned when no VBD matches the given VDI and VM combination.
+var ErrVBDNotFound = errors.New("VBD not found")
+
+// ErrVolumeNotFound is returned when no VDI matches the given volume handle.
+var ErrVolumeNotFound = errors.New("volume not found")
+
+// ErrVolumeIdAmbiguous is returned when multiple VDIs match the same CSI volume ID.
+var ErrVolumeIdAmbiguous = errors.New("multiple VDIs match volume ID")
+
+// ErrVolumeNameAmbiguous is returned when multiple VDIs match the same Kubernetes PV name.
+var ErrVolumeNameAmbiguous = errors.New("multiple VDIs match volume name")

--- a/pkg/xenorchestra-csi/clients/mock/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/mock/xoclient.go
@@ -74,6 +74,22 @@ func (mr *MockXoClientMockRecorder) ConnectVBDToVM(ctx, vbd any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectVBDToVM", reflect.TypeOf((*MockXoClient)(nil).ConnectVBDToVM), ctx, vbd)
 }
 
+// CreateNewVolume mocks base method.
+func (m *MockXoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, diskName string, capacityBytes int64, volumeName, createdBy, clusterTag string) (uuid.UUID, uuid.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNewVolume", ctx, srID, diskName, capacityBytes, volumeName, createdBy, clusterTag)
+	ret0, _ := ret[0].(uuid.UUID)
+	ret1, _ := ret[1].(uuid.UUID)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateNewVolume indicates an expected call of CreateNewVolume.
+func (mr *MockXoClientMockRecorder) CreateNewVolume(ctx, srID, diskName, capacityBytes, volumeName, createdBy, clusterTag any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewVolume", reflect.TypeOf((*MockXoClient)(nil).CreateNewVolume), ctx, srID, diskName, capacityBytes, volumeName, createdBy, clusterTag)
+}
+
 // DisconnectVBDFromVM mocks base method.
 func (m *MockXoClient) DisconnectVBDFromVM(ctx context.Context, vdi payloads.VDI, vmUUID uuid.UUID) error {
 	m.ctrl.T.Helper()
@@ -86,6 +102,22 @@ func (m *MockXoClient) DisconnectVBDFromVM(ctx context.Context, vdi payloads.VDI
 func (mr *MockXoClientMockRecorder) DisconnectVBDFromVM(ctx, vdi, vmUUID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisconnectVBDFromVM", reflect.TypeOf((*MockXoClient)(nil).DisconnectVBDFromVM), ctx, vdi, vmUUID)
+}
+
+// FindVDIByVolumeName mocks base method.
+func (m *MockXoClient) FindVDIByVolumeName(ctx context.Context, volumeName string) (*payloads.VDI, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindVDIByVolumeName", ctx, volumeName)
+	ret0, _ := ret[0].(*payloads.VDI)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// FindVDIByVolumeName indicates an expected call of FindVDIByVolumeName.
+func (mr *MockXoClientMockRecorder) FindVDIByVolumeName(ctx, volumeName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindVDIByVolumeName", reflect.TypeOf((*MockXoClient)(nil).FindVDIByVolumeName), ctx, volumeName)
 }
 
 // GetVBDFromVDIAndVM mocks base method.
@@ -103,6 +135,21 @@ func (mr *MockXoClientMockRecorder) GetVBDFromVDIAndVM(ctx, vdi, vmUUID any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVBDFromVDIAndVM", reflect.TypeOf((*MockXoClient)(nil).GetVBDFromVDIAndVM), ctx, vdi, vmUUID)
 }
 
+// GetVDIByVolumeId mocks base method.
+func (m *MockXoClient) GetVDIByVolumeId(ctx context.Context, volumeId string) (*payloads.VDI, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVDIByVolumeId", ctx, volumeId)
+	ret0, _ := ret[0].(*payloads.VDI)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVDIByVolumeId indicates an expected call of GetVDIByVolumeId.
+func (mr *MockXoClientMockRecorder) GetVDIByVolumeId(ctx, volumeId any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVDIByVolumeId", reflect.TypeOf((*MockXoClient)(nil).GetVDIByVolumeId), ctx, volumeId)
+}
+
 // Host mocks base method.
 func (m *MockXoClient) Host() library.Host {
 	m.ctrl.T.Helper()
@@ -115,6 +162,20 @@ func (m *MockXoClient) Host() library.Host {
 func (mr *MockXoClientMockRecorder) Host() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Host", reflect.TypeOf((*MockXoClient)(nil).Host))
+}
+
+// IsSRAttachedToHost mocks base method.
+func (m *MockXoClient) IsSRAttachedToHost(ctx context.Context, srID, hostID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSRAttachedToHost", ctx, srID, hostID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IsSRAttachedToHost indicates an expected call of IsSRAttachedToHost.
+func (mr *MockXoClientMockRecorder) IsSRAttachedToHost(ctx, srID, hostID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSRAttachedToHost", reflect.TypeOf((*MockXoClient)(nil).IsSRAttachedToHost), ctx, srID, hostID)
 }
 
 // IsSRAttachedToVMHost mocks base method.
@@ -144,20 +205,6 @@ func (m *MockXoClient) IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI)
 func (mr *MockXoClientMockRecorder) IsVDIUsedAnywhere(ctx, vdi any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVDIUsedAnywhere", reflect.TypeOf((*MockXoClient)(nil).IsVDIUsedAnywhere), ctx, vdi)
-}
-
-// IsSRAttachedToHost mocks base method.
-func (m *MockXoClient) IsSRAttachedToHost(ctx context.Context, srID uuid.UUID, hostID uuid.UUID) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsSRAttachedToHost", ctx, srID, hostID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// IsSRAttachedToHost indicates an expected call of IsSRAttachedToHost.
-func (mr *MockXoClientMockRecorder) IsSRAttachedToHost(ctx, srID, hostID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSRAttachedToHost", reflect.TypeOf((*MockXoClient)(nil).IsSRAttachedToHost), ctx, srID, hostID)
 }
 
 // PBD mocks base method.

--- a/pkg/xenorchestra-csi/clients/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/xoclient.go
@@ -42,7 +42,7 @@ type XoClient interface {
 	WaitForVDIToBeFullyAttached(ctx context.Context, vbdID uuid.UUID) (*payloads.VBD, error)
 	IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI) ([]*payloads.VBD, error)
 	// FindVDIByVolumeName looks up a VDI by the Kubernetes PV name stored in
-	// VDI.other_config["kubernetesPVName"]. It returns nil, nil when not found.
+	// VDI.other_config["kubernetes_pv_name"]. It returns nil, nil when not found.
 	FindVDIByVolumeName(ctx context.Context, volumeName string) (*payloads.VDI, string, error)
 	// IsSRAttachedToHost checks that the given SR is connected (via a plugged PBD) to the given host.
 	// Returns nil when the SR is reachable, or a descriptive error otherwise.
@@ -53,7 +53,7 @@ type XoClient interface {
 	IsSRAttachedToVMHost(ctx context.Context, vbdID uuid.UUID) error
 
 	// GetVDIByVolumeId looks up a VDI by its CSI volume ID (UUID).
-	// The ID is stored in VDI.other_config["csi-volume-handle"] at creation time
+	// The ID is stored in VDI.other_config["kubernetes_volume_id"] at creation time
 	// and remains stable across SR migrations.
 	// Returns ErrVolumeNotFound if no VDI matches, ErrVolumeIdAmbiguous if multiple match.
 	GetVDIByVolumeId(ctx context.Context, volumeId string) (*payloads.VDI, error)

--- a/pkg/xenorchestra-csi/clients/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/xoclient.go
@@ -17,7 +17,6 @@ package clients
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -29,9 +28,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// ErrVBDNotFound is returned when no VBD matches the given VDI and VM combination.
-var ErrVBDNotFound = errors.New("VBD not found")
-
 // This interface extends the library.Library interface to add methods specific to Xen Orchestra operations needed by the CSI driver.
 // It's done to encapsulate call to the legacy v1 client waiting for the v2 client to support all required operations.
 //
@@ -42,8 +38,12 @@ type XoClient interface {
 	ConnectVBDToVM(ctx context.Context, vbd payloads.VBD) (*payloads.VBD, error)
 	DisconnectVBDFromVM(ctx context.Context, vdi payloads.VDI, vmUUID uuid.UUID) error
 	AttachVDIToVM(ctx context.Context, vdi payloads.VDI, vmUUID uuid.UUID) (*payloads.VBD, error)
+	CreateNewVolume(ctx context.Context, srID uuid.UUID, diskName string, capacityBytes int64, volumeName string, createdBy string, clusterTag string) (uuid.UUID, uuid.UUID, error)
 	WaitForVDIToBeFullyAttached(ctx context.Context, vbdID uuid.UUID) (*payloads.VBD, error)
 	IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI) ([]*payloads.VBD, error)
+	// FindVDIByVolumeName looks up a VDI by the Kubernetes PV name stored in
+	// VDI.other_config["kubernetesPVName"]. It returns nil, nil when not found.
+	FindVDIByVolumeName(ctx context.Context, volumeName string) (*payloads.VDI, string, error)
 	// IsSRAttachedToHost checks that the given SR is connected (via a plugged PBD) to the given host.
 	// Returns nil when the SR is reachable, or a descriptive error otherwise.
 	IsSRAttachedToHost(ctx context.Context, srID uuid.UUID, hostID uuid.UUID) error
@@ -51,6 +51,12 @@ type XoClient interface {
 	// to the XCP-ng host where the VBD's VM is currently running.
 	// Returns nil when the SR is reachable, or a descriptive error otherwise.
 	IsSRAttachedToVMHost(ctx context.Context, vbdID uuid.UUID) error
+
+	// GetVDIByVolumeId looks up a VDI by its CSI volume ID (UUID).
+	// The ID is stored in VDI.other_config["csi-volume-handle"] at creation time
+	// and remains stable across SR migrations.
+	// Returns ErrVolumeNotFound if no VDI matches, ErrVolumeIdAmbiguous if multiple match.
+	GetVDIByVolumeId(ctx context.Context, volumeId string) (*payloads.VDI, error)
 }
 
 type xoClient struct {
@@ -123,6 +129,37 @@ func (c xoClient) AttachVDIToVM(ctx context.Context, vdi payloads.VDI, vmUUID uu
 	klog.V(4).InfoS("attachDiskToVM: disk attached", "vdi", vdi.ID, "vm", vmUUID, "vbd", vbd)
 
 	return vbd, nil
+}
+
+func (c xoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, diskName string, capacityBytes int64, volumeName string, createdBy string, clusterTag string) (uuid.UUID, uuid.UUID, error) {
+	volumeId, err := uuid.NewV4()
+	if err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("failed to generate volume ID UUID: %w", err)
+	}
+
+	otherConfig := map[string]string{
+		VDIOtherConfigKeyCreatedBy: createdBy,
+		VDIOtherConfigKeyPVName:    volumeName,
+		VDIOtherConfigKeyVolumeId:  volumeId.String(),
+	}
+
+	vdiParams := payloads.VDICreateParams{
+		SRId:            srID,
+		NameLabel:       diskName,
+		VirtualSize:     capacityBytes,
+		NameDescription: "VDI managed by the Kubernetes CSI",
+		OtherConfig:     otherConfig,
+	}
+	if clusterTag != "" {
+		vdiParams.Tags = []string{clusterTag}
+	}
+
+	vdiID, err := c.VDI().Create(ctx, vdiParams)
+	if err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("failed to create VDI: %w", err)
+	}
+
+	return vdiID, volumeId, nil
 }
 
 // waitForDiskToBeAttached waits for the disk to be attached.
@@ -219,4 +256,36 @@ func (c xoClient) DisconnectVBDFromVM(ctx context.Context, vdi payloads.VDI, vmU
 		klog.ErrorS(err, "Failed to wait for task to complete", "taskID", taskID, "taskResult", task.Result)
 	}
 	return err
+}
+
+func (c xoClient) GetVDIByVolumeId(ctx context.Context, volumeId string) (*payloads.VDI, error) {
+	filter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+	vdis, err := c.VDI().GetAll(ctx, 2, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list VDIs by volume ID %s: %w", volumeId, err)
+	}
+	switch len(vdis) {
+	case 0:
+		return nil, ErrVolumeNotFound
+	case 1:
+		return vdis[0], nil
+	default:
+		return nil, fmt.Errorf("%w: volumeId=%s matched %d VDIs", ErrVolumeIdAmbiguous, volumeId, len(vdis))
+	}
+}
+
+func (c xoClient) FindVDIByVolumeName(ctx context.Context, volumeName string) (*payloads.VDI, string, error) {
+	filter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyPVName, volumeName)
+	vdis, err := c.VDI().GetAll(ctx, 2, filter)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to list VDIs by volume name %s: %w", volumeName, err)
+	}
+	switch len(vdis) {
+	case 0:
+		return nil, "", ErrVolumeNotFound
+	case 1:
+		return vdis[0], vdis[0].OtherConfig[VDIOtherConfigKeyVolumeId], nil
+	default:
+		return nil, "", fmt.Errorf("%w: volumeName=%s matched %d VDIs", ErrVolumeNameAmbiguous, volumeName, len(vdis))
+	}
 }

--- a/pkg/xenorchestra-csi/constants.go
+++ b/pkg/xenorchestra-csi/constants.go
@@ -34,14 +34,6 @@ const (
 	// the same Xen Orchestra instance (e.g. "k8s-prod", "k8s-staging").
 	DefaultClusterTag = "k8s-managed"
 
-	// VDIOtherConfigKeyPVName is the key in VDI's other_config map that stores
-	// the Kubernetes PersistentVolume name associated with this VDI.
-	VDIOtherConfigKeyPVName = "kubernetesPVName"
-
-	// VDIOtherConfigKeyCreatedBy is the key in VDI's other_config map that identifies
-	// the component that created the VDI (always set to the driver name).
-	VDIOtherConfigKeyCreatedBy = "createdBy"
-
 	// VolumeContextKeySRID is the key in the PV's volumeAttributes (CSI VolumeContext)
 	// that stores the UUID of the Xen Orchestra Storage Repository backing the VDI.
 	VolumeContextKeySRID = "srId"

--- a/pkg/xenorchestra-csi/controllerserver.go
+++ b/pkg/xenorchestra-csi/controllerserver.go
@@ -18,7 +18,6 @@ package xenorchestracsi
 import (
 	"context"
 	"errors"
-	"fmt"
 	"slices"
 	"strings"
 
@@ -104,15 +103,17 @@ func (driver *xenorchestraCSIDriver) ControllerPublishVolume(ctx context.Context
 		return nil, status.Errorf(codes.InvalidArgument, "invalid volume capability: %v", err)
 	}
 
-	// Volume ID is the VDI UUID
-	volumeId, err := uuid.FromString(req.GetVolumeId())
-	if err != nil || volumeId == uuid.Nil {
+	volumeId := req.GetVolumeId()
+	if volumeId == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "volume ID is required")
 	}
 
-	vdi, err := driver.xoClient.VDI().Get(ctx, volumeId)
+	vdi, err := driver.xoClient.GetVDIByVolumeId(ctx, volumeId)
 	if err != nil {
-		return nil, status.Errorf(codes.NotFound, "failed to get VDI: %v", err)
+		if errors.Is(err, clients.ErrVolumeNotFound) {
+			return nil, status.Errorf(codes.NotFound, "volume %s not found: %v", volumeId, err)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to look up volume %s: %v", volumeId, err)
 	}
 
 	// Adopt the VDI into this cluster's tag set if the tag is not already present.
@@ -170,7 +171,6 @@ func (driver *xenorchestraCSIDriver) ControllerPublishVolume(ctx context.Context
 					klog.ErrorS(err, "Failed to connect VBD to VM", "vbd", *vbdToAttach, "vmUUID", vmUUID)
 					return nil, status.Errorf(codes.Internal, "Failed to connect VBD to VM: %v", err)
 				}
-				// Should be fixed by the addition of Device field in VBD
 				return &csi.ControllerPublishVolumeResponse{
 					PublishContext: publishContextFromVBD(*vbdConnected),
 				}, nil
@@ -218,22 +218,31 @@ func (driver *xenorchestraCSIDriver) ControllerUnpublishVolume(ctx context.Conte
 		return nil, status.Errorf(codes.InvalidArgument, "node ID is required")
 	}
 
-	// Volume ID is the VDI UUID
-	volumeId, err := uuid.FromString(req.GetVolumeId())
-	if err != nil || volumeId == uuid.Nil {
+	volumeId := req.GetVolumeId()
+	if volumeId == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "volume ID is required")
 	}
 
-	err = driver.xoClient.DisconnectVBDFromVM(ctx, payloads.VDI{ID: volumeId}, vmUUID)
+	vdi, err := driver.xoClient.GetVDIByVolumeId(ctx, volumeId)
+	if err != nil {
+		if errors.Is(err, clients.ErrVolumeNotFound) {
+			// VDI is already gone; idempotent success.
+			klog.V(5).InfoS("VDI not found, treating as already detached", "volumeID", volumeId)
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
+		return nil, status.Errorf(codes.Internal, "failed to look up volume %s: %v", volumeId, err)
+	}
+
+	err = driver.xoClient.DisconnectVBDFromVM(ctx, *vdi, vmUUID)
 	if err != nil {
 		// Ignore not found errors as the VBD may have already been detached
 		if !errors.Is(err, clients.ErrVBDNotFound) {
-			klog.ErrorS(err, "Failed to detach VDI from VM", "vdiID", volumeId, "vmUUID", vmUUID)
+			klog.ErrorS(err, "Failed to detach VDI from VM", "vdiID", vdi.ID, "vmUUID", vmUUID)
 			return nil, status.Errorf(codes.Internal, "Failed to detach VDI from VM: %v", err)
 		}
-		klog.V(5).InfoS("VBD not found, already detached", "vdiID", volumeId, "vmUUID", vmUUID)
+		klog.V(5).InfoS("VBD not found, already detached", "vdiID", vdi.ID, "vmUUID", vmUUID)
 	}
-	klog.V(5).InfoS("VBD disconnected from VM", "vdiID", volumeId, "vmUUID", vmUUID)
+	klog.V(5).InfoS("VBD disconnected from VM", "vdiID", vdi.ID, "vmUUID", vmUUID)
 
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
@@ -328,20 +337,28 @@ func (driver *xenorchestraCSIDriver) CreateVolume(ctx context.Context, req *csi.
 
 	klog.V(5).InfoS("Using pool and SR", "poolID", pool.ID, "srID", sr.ID)
 
-	existingVDIs, err := driver.xoClient.VDI().GetAll(ctx, 1, fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyPVName, volumeName))
+	// Idempotency check: return the existing VDI if one was already created for this PV name.
+	existingVDI, existingId, err := driver.xoClient.FindVDIByVolumeName(ctx, volumeName)
 	if err != nil {
-		klog.ErrorS(err, "Failed to check for existing VDI", "volumeName", volumeName)
-		return nil, status.Errorf(codes.Internal, "failed to check for existing VDI: %v", err)
+		if errors.Is(err, clients.ErrVolumeNotFound) {
+			existingVDI = nil
+		} else {
+			klog.ErrorS(err, "Failed to check for existing VDI", "volumeName", volumeName)
+			return nil, status.Errorf(codes.Internal, "failed to check for existing VDI: %v", err)
+		}
 	}
-	if len(existingVDIs) > 0 {
-		existingVDI := existingVDIs[0]
+	if existingVDI != nil {
 		if existingVDI.Size != capacityBytes {
 			return nil, status.Errorf(codes.AlreadyExists, "volume with name %q already exists with different capacity: existing %d, requested %d", volumeName, existingVDI.Size, capacityBytes)
 		}
-		klog.V(5).InfoS("Volume already exists, returning existing VDI", "vdiID", existingVDI.ID, "volumeName", volumeName)
+		// Recover the stable volume ID stored at creation time.
+		if existingId == "" {
+			return nil, status.Errorf(codes.Internal, "existing VDI %s is missing volume ID in other_config", existingVDI.ID)
+		}
+		klog.V(5).InfoS("Volume already exists, returning existing VDI", "vdiID", existingVDI.ID, "volumeId", existingId)
 		return &csi.CreateVolumeResponse{
 			Volume: &csi.Volume{
-				VolumeId:           existingVDI.ID.String(),
+				VolumeId:           existingId,
 				CapacityBytes:      capacityBytes,
 				AccessibleTopology: driver.buildAccessibleTopology(pool),
 				VolumeContext:      buildVolumeContext(pool, sr),
@@ -349,29 +366,16 @@ func (driver *xenorchestraCSIDriver) CreateVolume(ctx context.Context, req *csi.
 		}, nil
 	}
 
-	vdiParams := payloads.VDICreateParams{
-		SRId:            sr.ID,
-		NameLabel:       diskName,
-		VirtualSize:     capacityBytes,
-		NameDescription: "VDI managed by the Kubernetes CSI",
-		OtherConfig: map[string]string{
-			VDIOtherConfigKeyCreatedBy: DriverName,
-			VDIOtherConfigKeyPVName:    volumeName,
-		},
-	}
-	if driver.clusterTag != "" {
-		vdiParams.Tags = []string{driver.clusterTag}
-	}
-	vdiID, err := driver.xoClient.VDI().Create(ctx, vdiParams)
+	vdiID, volumeID, err := driver.xoClient.CreateNewVolume(ctx, sr.ID, diskName, capacityBytes, volumeName, DriverName, driver.clusterTag)
 	if err != nil {
 		klog.ErrorS(err, "Failed to create VDI", "diskName", diskName, "capacityBytes", capacityBytes)
 		return nil, status.Errorf(codes.Internal, "Failed to create VDI: %v", err)
 	}
-	klog.V(5).InfoS("VDI created", "vdiID", vdiID, "diskName", diskName, "capacityBytes", capacityBytes)
+	klog.V(5).InfoS("VDI created", "vdiID", vdiID, "volumeID", volumeID, "diskName", diskName)
 
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:           vdiID.String(),
+			VolumeId:           volumeID.String(),
 			CapacityBytes:      capacityBytes,
 			AccessibleTopology: driver.buildAccessibleTopology(pool),
 			VolumeContext:      buildVolumeContext(pool, sr),
@@ -389,50 +393,49 @@ func (driver *xenorchestraCSIDriver) DeleteSnapshot(context.Context, *csi.Delete
 func (driver *xenorchestraCSIDriver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	klog.V(5).Infof("DeleteVolume called, request: %v", req)
 
-	if req.GetVolumeId() == "" {
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "volume ID is required")
 	}
 
-	volumeID, err := uuid.FromString(req.GetVolumeId())
-	if err != nil || volumeID == uuid.Nil {
-		return &csi.DeleteVolumeResponse{}, nil // Treat invalid volume ID as already deleted to be idempotent
-	}
-
-	// Check whether the VDI still exists. Return success immediately if it is already gone
-	_, err = driver.xoClient.VDI().Get(ctx, volumeID)
+	vdi, err := driver.xoClient.GetVDIByVolumeId(ctx, volumeID)
 	if err != nil {
-		if isNotFoundError(err) {
+		if errors.Is(err, clients.ErrVolumeNotFound) {
 			klog.V(5).InfoS("VDI not found, treating as already deleted", "volumeID", volumeID)
 			return &csi.DeleteVolumeResponse{}, nil
 		}
-		klog.ErrorS(err, "Failed to get VDI", "volumeID", volumeID)
-		return nil, status.Errorf(codes.Internal, "failed to get VDI %s: %v", volumeID, err)
+		if errors.Is(err, clients.ErrVolumeIdAmbiguous) {
+			klog.ErrorS(err, "Multiple VDIs match volume ID, refusing deletion", "volumeID", volumeID)
+			return nil, status.Errorf(codes.Internal, "multiple VDIs match volume ID %s", volumeID)
+		}
+		klog.ErrorS(err, "Failed to look up volume", "volumeID", volumeID)
+		return nil, status.Errorf(codes.Internal, "failed to look up volume %s: %v", volumeID, err)
 	}
 
 	// Refuse to delete a VDI that is still attached to a VM.
-	vbds, err := driver.xoClient.IsVDIUsedAnywhere(ctx, &payloads.VDI{ID: volumeID})
+	vbds, err := driver.xoClient.IsVDIUsedAnywhere(ctx, vdi)
 	if err != nil {
-		klog.ErrorS(err, "Failed to check VDI attachments", "volumeID", volumeID)
-		return nil, status.Errorf(codes.Internal, "failed to check VDI attachments for %s: %v", volumeID, err)
+		klog.ErrorS(err, "Failed to check VDI attachments", "vdiID", vdi.ID)
+		return nil, status.Errorf(codes.Internal, "failed to check VDI attachments for %s: %v", vdi.ID, err)
 	}
 	for _, vbd := range vbds {
 		if vbd.Attached {
-			klog.ErrorS(nil, "VDI still attached to a VM, refusing deletion", "volumeID", volumeID, "vmID", vbd.VM)
-			return nil, status.Errorf(codes.FailedPrecondition, "volume %s is still attached to VM %s", volumeID, vbd.VM)
+			klog.ErrorS(nil, "VDI still attached to a VM, refusing deletion", "vdiID", vdi.ID, "vmID", vbd.VM)
+			return nil, status.Errorf(codes.FailedPrecondition, "VDI %s is still attached to VM %s", vdi.ID, vbd.VM)
 		}
 	}
 
-	if err := driver.xoClient.VDI().Delete(ctx, volumeID); err != nil {
+	if err := driver.xoClient.VDI().Delete(ctx, vdi.ID); err != nil {
 		if isNotFoundError(err) {
-			// Deleted by a concurrent call between our Get and Delete
-			klog.V(5).InfoS("VDI already deleted by concurrent call", "volumeID", volumeID)
+			// Deleted by a concurrent call between our lookup and Delete
+			klog.V(5).InfoS("VDI already deleted by concurrent call", "vdiID", vdi.ID)
 			return &csi.DeleteVolumeResponse{}, nil
 		}
-		klog.ErrorS(err, "Failed to delete VDI", "volumeID", volumeID)
-		return nil, status.Errorf(codes.Internal, "failed to delete VDI %s: %v", volumeID, err)
+		klog.ErrorS(err, "Failed to delete VDI", "vdiID", vdi.ID)
+		return nil, status.Errorf(codes.Internal, "failed to delete VDI %s: %v", vdi.ID, err)
 	}
 
-	klog.V(5).InfoS("VDI deleted successfully", "volumeID", volumeID)
+	klog.V(5).InfoS("VDI deleted successfully", "vdiID", vdi.ID, "volumeID", volumeID)
 	return &csi.DeleteVolumeResponse{}, nil
 }
 
@@ -458,26 +461,22 @@ func (driver *xenorchestraCSIDriver) ListVolumes(context.Context, *csi.ListVolum
 func (driver *xenorchestraCSIDriver) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	klog.V(5).Info("ValidateVolumeCapabilities called", "request", req)
 
-	if len(req.GetVolumeId()) == 0 {
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Volume ID is required")
-	}
-
-	volumeID, err := uuid.FromString(req.GetVolumeId())
-	if err != nil || volumeID == uuid.Nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Volume ID must be a valid UUID")
 	}
 
 	if len(req.GetVolumeCapabilities()) == 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "At least one volume capability is required")
 	}
 
-	_, err = driver.xoClient.VDI().Get(ctx, volumeID)
+	_, err := driver.xoClient.GetVDIByVolumeId(ctx, volumeID)
 	if err != nil {
-		if isNotFoundError(err) {
+		if errors.Is(err, clients.ErrVolumeNotFound) {
 			return nil, status.Errorf(codes.NotFound, "Volume %s not found", volumeID)
 		}
 		klog.ErrorS(err, "Failed to get VDI", "volumeID", volumeID)
-		return nil, status.Errorf(codes.Internal, "Failed to get VDI %s: %v", volumeID, err)
+		return nil, status.Errorf(codes.Internal, "Failed to get VDI for volume %s: %v", volumeID, err)
 	}
 
 	if err := validateVolumeCapabilities(req.GetVolumeCapabilities()); err != nil {
@@ -505,6 +504,8 @@ func (driver *xenorchestraCSIDriver) buildAccessibleTopology(pool *payloads.Pool
 	}
 }
 
+// buildVolumeContext constructs the CSI VolumeContext map that is stored in the PV's
+// volumeAttributes and passed back to ControllerPublishVolume / NodeStageVolume.
 func buildVolumeContext(pool *payloads.Pool, sr *payloads.StorageRepository) map[string]string {
 	return map[string]string{
 		VolumeContextKeySRID:     sr.ID.String(),

--- a/pkg/xenorchestra-csi/controllerserver.go
+++ b/pkg/xenorchestra-csi/controllerserver.go
@@ -111,6 +111,7 @@ func (driver *xenorchestraCSIDriver) ControllerPublishVolume(ctx context.Context
 	vdi, err := driver.xoClient.GetVDIByVolumeId(ctx, volumeId)
 	if err != nil {
 		if errors.Is(err, clients.ErrVolumeNotFound) {
+			klog.V(2).InfoS("Volume handle not found during ControllerPublishVolume", "volumeID", volumeId)
 			return nil, status.Errorf(codes.NotFound, "volume %s not found: %v", volumeId, err)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to look up volume %s: %v", volumeId, err)
@@ -428,7 +429,7 @@ func (driver *xenorchestraCSIDriver) DeleteVolume(ctx context.Context, req *csi.
 	if err := driver.xoClient.VDI().Delete(ctx, vdi.ID); err != nil {
 		if isNotFoundError(err) {
 			// Deleted by a concurrent call between our lookup and Delete
-			klog.V(5).InfoS("VDI already deleted by concurrent call", "vdiID", vdi.ID)
+			klog.V(4).InfoS("VDI not found during delete call, already deleted by concurrent call", "volumeID", volumeID, "vdiID", vdi.ID)
 			return &csi.DeleteVolumeResponse{}, nil
 		}
 		klog.ErrorS(err, "Failed to delete VDI", "vdiID", vdi.ID)
@@ -473,6 +474,7 @@ func (driver *xenorchestraCSIDriver) ValidateVolumeCapabilities(ctx context.Cont
 	_, err := driver.xoClient.GetVDIByVolumeId(ctx, volumeID)
 	if err != nil {
 		if errors.Is(err, clients.ErrVolumeNotFound) {
+			klog.V(2).InfoS("VDI not found during ValidateVolumeCapabilities", "volumeID", volumeID)
 			return nil, status.Errorf(codes.NotFound, "Volume %s not found", volumeID)
 		}
 		klog.ErrorS(err, "Failed to get VDI", "volumeID", volumeID)

--- a/test/sanity/fakedriver_test.go
+++ b/test/sanity/fakedriver_test.go
@@ -3,7 +3,6 @@ package sanity_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
 
@@ -11,6 +10,7 @@ import (
 	gomock "go.uber.org/mock/gomock"
 
 	xenorchestracsi "github.com/vatesfr/xenorchestra-csi-driver/pkg/xenorchestra-csi"
+	"github.com/vatesfr/xenorchestra-csi-driver/pkg/xenorchestra-csi/clients"
 	clientsMock "github.com/vatesfr/xenorchestra-csi-driver/pkg/xenorchestra-csi/clients/mock"
 	"github.com/vatesfr/xenorchestra-csi-driver/pkg/xenorchestra-csi/clients/stub"
 	"github.com/vatesfr/xenorchestra-go-sdk/pkg/payloads"
@@ -44,8 +44,73 @@ func NewFakeDriver(t *testing.T, options *xenorchestracsi.DriverOptions, fakeMou
 	mockXoClient.EXPECT().VM().Return(mockVM).AnyTimes()
 	mockXoClient.EXPECT().SR().Return(mockSR).AnyTimes()
 
+	mockXoClient.EXPECT().CreateNewVolume(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, srID uuid.UUID, diskName string, capacityBytes int64, volumeName string, _ string, _ string) (uuid.UUID, uuid.UUID, error) {
+			vdiID := uuid.Must(uuid.NewV4())
+			volumeId := uuid.Must(uuid.NewV4())
+			vdiStore.Lock()
+			defer vdiStore.Unlock()
+			vdiStore.byID[vdiID] = payloads.VDI{
+				ID:        vdiID,
+				SR:        srID,
+				NameLabel: diskName,
+				Size:      capacityBytes,
+				OtherConfig: map[string]string{
+					clients.VDIOtherConfigKeyPVName:   volumeName,
+					clients.VDIOtherConfigKeyVolumeId: volumeId.String(),
+				},
+				PoolID: uuid.FromStringOrNil(stub.PoolId),
+			}
+			return vdiID, volumeId, nil
+		}).AnyTimes()
+
 	// IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI) ([]*payloads.VBD, error)
 	mockXoClient.EXPECT().IsVDIUsedAnywhere(gomock.Any(), gomock.Any()).Return([]*payloads.VBD{}, nil).AnyTimes()
+	mockXoClient.EXPECT().FindVDIByVolumeName(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, volumeName string) (*payloads.VDI, string, error) {
+		vdiStore.RLock()
+		defer vdiStore.RUnlock()
+
+		var matched *payloads.VDI
+		for _, vdi := range vdiStore.byID {
+			if vdi.OtherConfig[clients.VDIOtherConfigKeyPVName] != volumeName {
+				continue
+			}
+			if matched != nil {
+				return nil, "", fmt.Errorf("%w: volumeName=%s matched multiple VDIs", clients.ErrVolumeNameAmbiguous, volumeName)
+			}
+			vdiCopy := vdi
+			matched = &vdiCopy
+		}
+
+		if matched == nil {
+			return nil, "", clients.ErrVolumeNotFound
+		}
+
+		return matched, matched.OtherConfig[clients.VDIOtherConfigKeyVolumeId], nil
+	}).AnyTimes()
+	mockXoClient.EXPECT().GetVDIByVolumeId(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, volumeId string) (*payloads.VDI, error) {
+		vdiStore.RLock()
+		defer vdiStore.RUnlock()
+
+		var matched *payloads.VDI
+		for _, vdi := range vdiStore.byID {
+			if vdi.OtherConfig[clients.VDIOtherConfigKeyVolumeId] != volumeId {
+				continue
+			}
+			if matched != nil {
+				return nil, fmt.Errorf("%w: volumeId=%s matched multiple VDIs", clients.ErrVolumeIdAmbiguous, volumeId)
+			}
+			vdiCopy := vdi
+			matched = &vdiCopy
+		}
+
+		if matched == nil {
+			return nil, clients.ErrVolumeNotFound
+		}
+
+		return matched, nil
+	}).AnyTimes()
+
 	device := "/dev/xvdc"
 	mockXoClient.EXPECT().AttachVDIToVM(gomock.Any(), gomock.Any(), gomock.Any()).Return(&payloads.VBD{
 		ID:     uuid.Must(uuid.NewV4()),
@@ -95,22 +160,6 @@ func newMockPool(ctrl *gomock.Controller) *xoLibMock.MockPool {
 
 func newMockVDI(ctrl *gomock.Controller) *xoLibMock.MockVDI {
 	mockVDI := xoLibMock.NewMockVDI(ctrl)
-	mockVDI.EXPECT().GetAll(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ int, filters string) ([]*payloads.VDI, error) {
-		vdiStore.RLock()
-		defer vdiStore.RUnlock()
-
-		// Parse "other_config:VDIOtherConfigKeyPVName:<value>" filter
-		prefix := fmt.Sprintf("other_config:%s:", xenorchestracsi.VDIOtherConfigKeyPVName)
-		filterValue, hasFilter := strings.CutPrefix(filters, prefix)
-		vdis := make([]*payloads.VDI, 0, len(vdiStore.byID))
-		for _, vdi := range vdiStore.byID {
-			if hasFilter && strings.Compare(vdi.OtherConfig[xenorchestracsi.VDIOtherConfigKeyPVName], filterValue) != 0 {
-				continue
-			}
-			vdis = append(vdis, &vdi)
-		}
-		return vdis, nil
-	}).AnyTimes()
 	mockVDI.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, id uuid.UUID) (*payloads.VDI, error) {
 		vdiStore.RLock()
 		defer vdiStore.RUnlock()
@@ -119,21 +168,6 @@ func newMockVDI(ctrl *gomock.Controller) *xoLibMock.MockVDI {
 			return nil, fmt.Errorf("API error: 404 Not Found - {\n  \"error\": \"no such VDI %s\",\n  \"data\": {\n    \"id\": \"%s\",\n    \"type\": \"VDI\"\n  }\n}", id, id)
 		}
 		return &vdi, nil
-	}).AnyTimes()
-	mockVDI.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, p payloads.VDICreateParams) (uuid.UUID, error) {
-		id := uuid.Must(uuid.NewV4())
-		vdiStore.Lock()
-		defer vdiStore.Unlock()
-		vdiStore.byID[id] = payloads.VDI{
-			ID:              id,
-			SR:              p.SRId,
-			NameLabel:       p.NameLabel,
-			Size:            p.VirtualSize,
-			NameDescription: p.NameDescription,
-			OtherConfig:     p.OtherConfig,
-			PoolID:          uuid.FromStringOrNil(stub.PoolId),
-		}
-		return id, nil
 	}).AnyTimes()
 	mockVDI.EXPECT().Delete(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, id uuid.UUID) error {
 		vdiStore.Lock()


### PR DESCRIPTION
## Problem

The CSI volume handle was previously the XO VDI UUID, which is reassigned when a VDI is migrated to another Storage Repository. This caused `ControllerPublishVolume` and `DeleteVolume` to fail for any PV whose backing VDI had been migrated, since the stored handle no longer resolved to a valid VDI.

Additionally, VDI lookup and creation logic was spread across `controllerserver.go`, mixing XO-specific concerns (filter syntax, `other_config` key names) into the CSI handler layer.

## Solution

**Stable volume ID:** `CreateVolume` now generates a random UUID as the CSI volume handle. This UUID is stored in `VDI.other_config["csi-volume-handle"]` at creation time and survives SR migration. All subsequent operations (`DeleteVolume`, `ControllerPublishVolume`, `ControllerUnpublishVolume`, `ValidateVolumeCapabilities`) resolve the VDI via this stable key rather than the mutable VDI UUID.

**Encapsulation in `XoClient`:** Three new methods abstract the XO-specific lookup and creation logic away from the controller:

- `GetVDIByVolumeId(ctx, volumeId)` — looks up a VDI by `other_config["csi-volume-handle"]`; returns `ErrVolumeNotFound` or `ErrVolumeIdAmbiguous` as typed sentinels
- `FindVDIByVolumeName(ctx, volumeName)` — looks up a VDI by `other_config["kubernetesPVName"]` for the idempotency check in `CreateVolume`; also returns the stored volume ID
- `CreateNewVolume(ctx, ...)` — generates the volume ID UUID, builds `other_config`, creates the VDI, and returns both the VDI UUID and the stable volume ID

**Constants and errors reorganised:** VDI `other_config` key constants (`VDIOtherConfigKeyVolumeId`, `VDIOtherConfigKeyCreatedBy`, `VDIOtherConfigKeyPVName`) and error sentinels (`ErrVolumeNotFound`, `ErrVolumeIdAmbiguous`, `ErrVolumeNameAmbiguous`) move into the `clients` package, co-located with the code that uses them. The duplicate declarations in `constants.go` are removed.

**Sanity tests updated:** The fake driver in `test/sanity/` is updated to implement the new `XoClient` methods, replacing the lower-level `VDI().GetAll` / `VDI().Create` mocks with the higher-level `CreateNewVolume`, `FindVDIByVolumeName`, and `GetVDIByVolumeId` mocks that mirror the real implementation.

## Impact

- **Breaking change for existing PVs:** PVs provisioned before this change store a VDI UUID as their volume handle. Those handles will not resolve via the new `other_config` lookup. A migration path is work in progress.
- No change to the node server, identity server, or topology logic.