### PR TITLE
feat: add local storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,40 @@ you cannot run the CCM (see [Topology and Placement](docs/topology.md)).
 - [Installation guide](docs/install.md) – requirements, credentials, StorageClass, static and dynamic provisioning.
 - [Topology and Placement](docs/topology.md) – pool boundary, live migration behaviour, CCM dependency.
 - [Developer guide](docs/development.md) – build, `kxo` helper, DevSpace, MicroK8s registry, remote debugging.
-- [Migration v0.2.0 to v0.3.0](docs/migrations/v0.2.0-to-v0.3.0.md) – backfill `other-config:kubernetes_volume_id` on legacy VDIs.
 - [Reference: Volume Handle and Volume ID in v0.3.0](docs/references/volume-handle-and-volume-id-v0.3.0.md) – details about stable CSI identity semantics.
+- [Reference: VDI Lookup and Identification](docs/references/vdi-lookup-and-identification.md) – how VDIs are located, `other_config` erasure, fallback behaviour, and limitations.
 - [Reference: Local Storage: VDI Placement and Migration](docs/references/local-storage.md) – SR selection, VDI migration, idempotency, and VM live-migration behaviour.
+
+## Version migrations
+
+When upgrading between versions, some releases require or recommend metadata
+changes to existing VDIs. Each guide is self-contained and includes rollback
+instructions.
+
+- [v0.2.0 to v0.3.0](docs/migrations/v0.2.0-to-v0.3.0.md) – **required** — backfill `other-config:kubernetes_volume_id` on legacy VDIs.
+- [v0.3.0 to v0.4.0](docs/migrations/v0.3.0-to-v0.4.0.md) – **optional** — backfill `name_label` with volume ID for pre-v0.4.0 VDIs (recommended before any VDI migration).
+
+## Limitations
+
+### Do not rename CSI-managed VDIs in Xen Orchestra
+
+The driver uses the VDI `name_label` as a fallback lookup when the
+`other_config:kubernetes_volume_id` key is missing (e.g. after a VDI
+migration). The `name_label` is set at creation time
+to `<prefix><volumeId>-<volumeName>`.
+
+**Renaming a VDI in Xen Orchestra breaks this fallback.** If `other_config`
+has also been erased, the driver will no longer be able to locate the VDI and
+volume operations (`DeleteVolume`, `ControllerUnpublishVolume`) will fail  and
+the VDI will be considered deleted.
+
+CSI-managed VDIs are identifiable by:
+- the `csi-` prefix in their `name_label` (or the prefix set with the flag `--vdi-name-prefix`),
+- the `kubernetes_created_by` key in their `other_config`,
+- the `name_description` field set to `VDI managed by the Kubernetes CSI; pv-name=<pv-name>`.
+
+See [VDI Lookup and Identification](docs/references/vdi-lookup-and-identification.md)
+for full details and manual recovery steps.
 
 ## Install driver on a Kubernetes cluster
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ you cannot run the CCM (see [Topology and Placement](docs/topology.md)).
 
 - Static volume provisioning (use an existing VDI by UUID).
 - Dynamic volume provisioning (automatically create a VDI from a StorageClass).
+- Local storage support: pin VDIs to a host-local SR with automatic migration on reschedule.
 
 ## Prerequisite
 
@@ -38,6 +39,7 @@ you cannot run the CCM (see [Topology and Placement](docs/topology.md)).
 - [Developer guide](docs/development.md) – build, `kxo` helper, DevSpace, MicroK8s registry, remote debugging.
 - [Migration v0.2.0 to v0.3.0](docs/migrations/v0.2.0-to-v0.3.0.md) – backfill `other-config:kubernetes_volume_id` on legacy VDIs.
 - [Reference: Volume Handle and Volume ID in v0.3.0](docs/references/volume-handle-and-volume-id-v0.3.0.md) – details about stable CSI identity semantics.
+- [Reference: Local Storage: VDI Placement and Migration](docs/references/local-storage.md) – SR selection, VDI migration, idempotency, and VM live-migration behaviour.
 
 ## Install driver on a Kubernetes cluster
 
@@ -105,6 +107,7 @@ an error is returned if they are incompatible.
 Name | Meaning | Example | Required | Default
 --- | --- | --- | --- | ---
 `poolId` | UUID of the Xen Orchestra pool. The VDI is created on the pool's default SR. | `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee` | No | —
+`storageType` | Storage placement: `shared` (pool default SR) or `local` (host-local SR, migrated at attach time). | `local` | No | `shared`
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -181,10 +184,11 @@ allowVolumeExpansion: false
 - [x] `poolId` validation against `accessibility_requirements` requisite topologies
 - [x] `VOLUME_ACCESSIBILITY_CONSTRAINTS` controller capability — `AccessibleTopology` returned in `CreateVolumeResponse`, topology requirements honoured in `CreateVolumeRequest`
 - [x] Cluster tag filtering (`--cluster-tag`; VDIs tagged at creation)
-- [ ] Cluster Topology support
+- [x] Cluster Topology support
 - [ ] Multi-SR support (migration...)
-- [ ] Multi-pool support
-- [ ] XO CCM
+- [x] Local SR support (`storageType: local` — VDI migration to host-local SR in `ControllerPublishVolume`)
+- [x] Multi-pool support
+- [x] XO CCM
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,10 @@ This folder is organized by purpose:
 ## Migrations
 
 - [v0.2.0 to v0.3.0](migrations/v0.2.0-to-v0.3.0.md)
+- [v0.3.0 to v0.4.0](migrations/v0.3.0-to-v0.4.0.md) *(optional — backfill `name_label` with volume ID for pre-v0.4.0 VDIs)*
 
 ## References
 
 - [Volume Handle and Volume ID in v0.3.0](references/volume-handle-and-volume-id-v0.3.0.md)
 - [Local Storage: VDI Placement and Migration](references/local-storage.md)
+- [VDI Lookup and Identification](references/vdi-lookup-and-identification.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,4 @@ This folder is organized by purpose:
 ## References
 
 - [Volume Handle and Volume ID in v0.3.0](references/volume-handle-and-volume-id-v0.3.0.md)
+- [Local Storage: VDI Placement and Migration](references/local-storage.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -244,6 +244,37 @@ allowVolumeExpansion: false
 See [Topology and Placement](topology.md) for a detailed explanation of how pool
 selection works in each mode.
 
+##### Local SR (host-pinned)
+
+Set `storageType: local`. The driver creates the VDI on one of the pool local SRs at
+provision time, then migrates it to the target host local SR in
+`ControllerPublishVolume` before attaching it to the VM.
+
+This mode requires `volumeBindingMode: WaitForFirstConsumer` (so the target node
+is known before provisioning) and every host must have at least one
+accessible local user-data SR.
+
+```bash
+kubectl apply -f examples/csi-app-local-storage.yaml
+```
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-xenorchestra-sc-local
+provisioner: csi.xenorchestra.vates.tech
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+parameters:
+  storageType: local
+  # poolId: "<xo-pool-uuid>"   # optional; omit for topology-aware mode
+```
+
+See [Local Storage reference](references/local-storage.md) for full details on SR
+selection, VDI migration, idempotency, and VM live-migration behaviour.
+
 #### Static provisioning (pre-existing VDI)
 
 No `poolId` is required. The volume is identified by its VDI UUID in the PV manifest.
@@ -412,6 +443,7 @@ csi.xenorchestra.vates.tech
 | Parameter | Description | Required | Example |
 | --------- | ----------- | -------- | ------- |
 | `poolId` | UUID of the Xen Orchestra pool. The VDI is created on the pool's default SR. If omitted, the pool is selected automatically from `accessibility_requirements` (topology-aware mode). | No | `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee` |
+| `storageType` | Storage placement strategy. `shared` (default): VDI stays on the pool's shared default SR. `local`: VDI is migrated to the target host's local SR in `ControllerPublishVolume`. | No | `local` |
 
 ### Driver startup flags
 

--- a/docs/migrations/v0.3.0-to-v0.4.0.md
+++ b/docs/migrations/v0.3.0-to-v0.4.0.md
@@ -1,0 +1,130 @@
+# Migration Guide v0.3.0 to v0.4.0
+
+## Summary
+
+v0.4.0 changes the VDI `name_label` format to embed the CSI volume ID:
+
+- **v0.3.0 format**: `<prefix><volumeName>` (e.g. `csi-pvc-my-app-data`)
+- **v0.4.0 format**: `<prefix><volumeId>-<volumeName>` (e.g. `csi-12345678-90ab-cdef-pvc-my-app-data`)
+
+This change enables a `name_label`-based fallback lookup when
+`other_config:kubernetes_volume_id` has been erased (e.g. after a VDI
+migration across SRs or a manual admin operation). See
+[VDI Lookup and Identification](../references/vdi-lookup-and-identification.md)
+for background.
+
+**This migration is optional.** Volumes created before v0.4.0 continue to
+work normally as long as `other_config:kubernetes_volume_id` is intact. The
+migration only becomes necessary if you want the fallback to work for legacy
+volumes — for example, before performing a VDI migration or SR consolidation
+that may erase `other_config`.
+
+---
+
+## Why apply this migration
+
+After upgrading to v0.4.0 newly provisioned volumes automatically include the
+CSI volume ID in their `name_label` and benefit from the fallback.
+
+Volumes provisioned under v0.3.0 keep their old `name_label` and do **not**
+benefit from the fallback. If their `other_config` is subsequently erased (by
+a VDI migration or admin operation), the driver will fail to
+locate them.
+
+Applying the migration re-labels legacy VDIs to the new format so that the
+fallback is available for them too.
+
+---
+
+## Prerequisites
+
+- Access to an XCP-ng host with `xe` CLI privileges.
+- The list of VDI UUIDs used by existing Kubernetes PersistentVolumes.
+- The CSI volume ID (`kubernetes_volume_id`) must be present in `other_config`
+  for each VDI — if it is missing, apply the
+  [v0.2.0 to v0.3.0 migration](v0.2.0-to-v0.3.0.md) first.
+- A maintenance window is recommended. The rename is instant and non-destructive
+  but it is good practice to avoid concurrent volume operations.
+
+---
+
+## Single-volume migration
+
+### 1. Retrieve the current metadata
+
+```bash
+xe vdi-param-get uuid=<VDI_UUID> param-name=name-label
+xe vdi-param-get uuid=<VDI_UUID> param-name=other-config
+```
+
+Note the current `name_label` value (e.g. `csi-pvc-my-app-data`) and the
+value of `kubernetes_volume_id` in `other-config` (e.g.
+`12345678-90ab-cdef-1234-567890abcdef`).
+
+Also note the `kubernetes_pv_name` value — this is the `<volumeName>` part
+of the new label.
+
+### 2. Build the new name_label
+
+The new format is: `<currentPrefix><volumeId>-<volumeName>`
+
+Where:
+- `<currentPrefix>` is the `csi-` prefix (or the custom prefix configured
+  via `--vdi-name-prefix` on the driver).
+- `<volumeId>` is the value of `other_config:kubernetes_volume_id`.
+- `<volumeName>` is the value of `other_config:kubernetes_pv_name`.
+
+Example:
+- Current `name_label`: `csi-pvc-my-app-data`
+- `kubernetes_volume_id`: `12345678-90ab-cdef-1234-567890abcdef`
+- `kubernetes_pv_name`: `pvc-my-app-data`
+- New `name_label`: `csi-12345678-90ab-cdef-1234-567890abcdef-pvc-my-app-data`
+
+### 3. Apply the rename
+
+```bash
+xe vdi-param-set uuid=<VDI_UUID> name-label=<NEW_NAME_LABEL>
+```
+
+Example:
+
+```bash
+xe vdi-param-set uuid=3ceb6f8c-4226-4133-92f6-52ec7be8cc4d \
+  name-label="csi-12345678-90ab-cdef-1234-567890abcdef-pvc-my-app-data"
+```
+
+### 4. Verify
+
+```bash
+xe vdi-param-get uuid=<VDI_UUID> param-name=name-label
+```
+
+Expected output:
+
+```
+csi-12345678-90ab-cdef-1234-567890abcdef-pvc-my-app-data
+```
+
+---
+
+## Rollback
+
+The rename is non-destructive. To restore the original `name_label`:
+
+```bash
+xe vdi-param-set uuid=<VDI_UUID> name-label=<ORIGINAL_NAME_LABEL>
+```
+
+No other metadata is modified by this migration.
+
+---
+
+## Post-migration checks
+
+- Confirm existing PVs can still be attached and mounted.
+- Verify the new `name_label` contains the volume ID:
+  ```bash
+  xe vdi-param-get uuid=<VDI_UUID> param-name=name-label
+  ```
+- Validate that new volumes provisioned after the upgrade already carry the
+  new format (no manual action needed for those).

--- a/docs/references/local-storage.md
+++ b/docs/references/local-storage.md
@@ -91,3 +91,62 @@ If the task fails or is interrupted, `ControllerPublishVolume` returns
 The driver checks `vdi.SR == localSR.ID` before initiating migration. If the VDI
 is already on the target host's local SR the migration step is skipped entirely.
 This makes `ControllerPublishVolume` safe to retry.
+
+---
+
+## Operational notes
+
+### Use `WaitForFirstConsumer`
+
+```yaml
+volumeBindingMode: WaitForFirstConsumer
+```
+
+This is **strongly recommended** for `storageType: local` StorageClasses. It
+ensures the scheduler picks a node before `CreateVolume` runs, so topology hints
+(`accessibility_requirements`) are available and the pool can be derived
+automatically (topology-aware mode).
+
+Without `WaitForFirstConsumer`, `CreateVolume` may be called before any node is
+known. In that case, the driver can still create the VDI on a local SR of the
+selected pool, but it may later need an additional migration at
+`ControllerPublishVolume` if the workload lands on a different host.
+
+### Every node must have a local SR
+
+`FindLocalSRForHost` returns `FailedPrecondition` if no local SR is found for the
+target host. Ensure every XCP-ng host in the pool has at least one accessible
+user-data local SR (e.g. `ext`, `lvm`, `zfs`).
+
+### StorageClass example
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-xenorchestra-sc-local
+provisioner: csi.xenorchestra.vates.tech
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+parameters:
+  storageType: local
+  # poolId: "<xo-pool-uuid>"   # optional; omit for topology-aware mode
+```
+
+See `examples/csi-app-local-storage.yaml` for a complete PVC + Pod example.
+
+### Performance
+
+Local SRs bypass network storage latency. They are well-suited for
+latency-sensitive workloads (databases, caches) that do not require shared access
+or cross-node mobility.
+
+### Limitations
+
+- A VDI on a local SR **cannot** be attached to a VM on a different host. If the
+  VM is migrated without first migrating the VDI, XAPI will reject the VBD
+  attachment. The CSI driver handles this automatically via `ControllerPublishVolume`.
+- `ReadWriteMany` is not supported for local storage (not supported in general by
+  this driver today).
+- Volume expansion is not yet implemented.

--- a/docs/references/local-storage.md
+++ b/docs/references/local-storage.md
@@ -1,0 +1,93 @@
+# Local Storage: VDI Placement and Migration
+
+## Overview
+
+The `storageType: local` StorageClass parameter instructs the driver to pin each
+VDI to a host-local SR. Unlike shared storage (NFS, iSCSI, Ceph…), a local SR is
+physically attached to a single XCP-ng host; only VMs running on that host can mount
+VDIs stored there.
+
+This document covers:
+
+- [How SR selection works at provision time](#sr-selection-at-createvolume)
+- [How VDI migration works at attach time](#vdi-migration-at-controllerpublishvolume)
+- [Idempotency guarantees](#idempotency)
+- [What happens when a VM is live-migrated](#vm-live-migration)
+- [Operational notes and recommendations](#operational-notes)
+
+---
+
+## SR selection at CreateVolume
+
+At `CreateVolume` time the Kubernetes scheduler has picked a node (assuming
+`volumeBindingMode: WaitForFirstConsumer`), but the driver does **not** yet know
+which host the pod will run on. The target host is only available in
+`ControllerPublishVolume`.
+
+To avoid blocking `CreateVolume`, the driver follows a two-phase approach:
+
+1. **Provision phase (`CreateVolume`)**: the pool is selected via the normal
+   pool-selection logic (`poolId` parameter or topology-aware mode), then the
+   driver calls `FindLocalSRsForPool` and picks one local SR from that pool for
+   initial VDI creation.
+
+   If no local SR is available in the selected pool, `CreateVolume` fails
+   immediately with `FailedPrecondition`.
+
+2. **Attach phase (`ControllerPublishVolume`)**: once the target node VM is
+   resolved, the driver calls `FindLocalSRForHost` to locate the local SR that
+   belongs to the target XCP-ng host.
+
+   If the VDI is already on that SR, no migration is needed. Otherwise, the
+   driver migrates the VDI to the host's local SR before attaching it.
+
+### `FindLocalSRsForPool`
+
+Uses the XenOrchestra filter:
+
+```
+content_type:user !shared? !inMaintenanceMode? $PBDs:length:>=1 $pool:<poolID>
+```
+
+- `content_type:user` — only user-data SRs (excludes ISO libraries, XenServer tools, etc.)
+- `!shared?` — shared flag is false or missing (host-local SRs)
+- `!inMaintenanceMode?` — SR is not in maintenance mode
+- `$PBDs:length:>=1` — SR has at least one connected PBD
+- `$pool:<poolID>` — scoped to the target pool
+
+### `FindLocalSRForHost`
+
+Uses the XenOrchestra filter:
+
+```
+content_type:user !shared? !inMaintenanceMode? $PBDs:length:>=1 $container:<hostID>
+```
+
+Same tokens as above, with `$container:<hostID>` scoping the result to a specific
+XCP-ng host. Returns the first matching SR (`limit: 1`).
+
+---
+
+## VDI migration at ControllerPublishVolume
+
+When `storageType: local` and the VDI is not already on the correct local SR, the
+driver calls `MigrateVDIAndWait`:
+
+1. **`VDI().Migrate(ctx, vdiID, targetSRID)`** — initiates the migration and
+   returns a XO task ID.
+2. **`Task().Wait(ctx, taskID)`** — blocks until the task completes or fails.
+3. On success, `task.Result.ID` (type `uuid.UUID`) is the **new VDI UUID**. The
+   original UUID is no longer valid after migration.
+4. The driver re-fetches the VDI by its new UUID and continues with
+   `IsSRAttachedToHost`, `IsVDIUsedAnywhere`, and `AttachVDIToVM`.
+
+If the task fails or is interrupted, `ControllerPublishVolume` returns
+`codes.Internal` with the task status and result details.
+
+---
+
+## Idempotency
+
+The driver checks `vdi.SR == localSR.ID` before initiating migration. If the VDI
+is already on the target host's local SR the migration step is skipped entirely.
+This makes `ControllerPublishVolume` safe to retry.

--- a/docs/references/vdi-lookup-and-identification.md
+++ b/docs/references/vdi-lookup-and-identification.md
@@ -1,0 +1,112 @@
+# VDI Lookup and Identification
+
+## Scope
+
+This reference describes how the driver identifies and locates VDIs during
+volume lifecycle operations (`DeleteVolume`, `ControllerPublishVolume`,
+`ControllerUnpublishVolume`), and documents the known limitations around
+`other_config` erasure.
+
+---
+
+## Primary lookup: `other_config`
+
+The driver's stable CSI volume ID is stored at creation time in the VDI
+`other_config` map under the key `kubernetes_volume_id`.
+
+Every lookup first queries XO with the filter:
+
+```
+other_config:kubernetes_volume_id:<volumeId>
+```
+
+This is the authoritative source of truth. Under normal operating conditions
+this lookup always succeeds.
+
+---
+
+## Fallback lookup: `name_label`
+
+The VDI `name_label` is set at creation time to:
+
+```
+<vdiNamePrefix><volumeId>-<volumeName>
+```
+
+For example: `csi-12345678-90ab-cdef-pvc-my-app-data`
+
+Because the CSI `volumeId` UUID is embedded in the name, the driver can
+fall back to searching by `name_label` if `other_config` returns no results:
+
+```
+name_label:<volumeId>
+```
+
+The fallback is transparent to callers — `DeleteVolume`,
+`ControllerPublishVolume`, and `ControllerUnpublishVolume` all benefit from it
+automatically.
+
+---
+
+## When `other_config` can be erased
+
+The `other_config` map is XenServer/XCP-ng metadata that may be lost in
+certain operational scenarios:
+
+- **VDI migration** — migrations do not carry `other_config` to the destination SR.
+- **Manual admin edits** — an operator clearing `other_config` via the XAPI shell.
+
+When `other_config:kubernetes_volume_id` is gone the driver automatically
+retries using the `name_label` fallback described above.
+
+---
+
+## Limitations
+
+### VDI name_label must not be changed
+
+The `name_label` fallback relies on the VDI name remaining unchanged from
+the value set at creation. **Renaming a VDI in Xen Orchestra will break the
+fallback** and cause volume operations to fail with `ErrVolumeNotFound` if
+`other_config` has also been erased.
+
+> **Do not rename CSI-managed VDIs in Xen Orchestra.**
+> CSI-managed VDIs are identifiable by the `csi-` prefix in their name
+> and the `kubernetes_created_by` key in their `other_config`.
+
+### Both `other_config` and `name_label` are lost
+
+If both `other_config` and `name_label` are modified or lost, the driver
+can no longer locate the VDI automatically. Manual recovery is required:
+
+1. Identify the VDI in XO by its size, SR, and the `name_description`
+   field (set to `VDI managed by the Kubernetes CSI; pv-name=<pv-name>`).
+2. Restore the `other_config:kubernetes_volume_id` key to the CSI
+   volume ID stored in the PersistentVolume's `.spec.volumeHandle`.
+3. Or restore the `name_label` to `<vdiNamePrefix><volumeId>-<volumeName>`.
+
+### `DeleteVolume` with no fallback available
+
+If neither `other_config` nor `name_label` allow the VDI to be located,
+`DeleteVolume` returns the volume as deleted. Although the PV is deleted
+from Kubernetes, the VDI remains in Xen Orchestra.
+
+
+---
+
+## VDI metadata reference
+
+| Field | Value | Purpose |
+|-------|-------|---------|
+| `name_label` | `<prefix><volumeId>-<volumeName>` | Human-readable name; used as fallback lookup key |
+| `name_description` | `VDI managed by the Kubernetes CSI; pv-name=<pv-name>` | Human-readable only; not used for lookups |
+| `other_config:kubernetes_volume_id` | CSI volume ID (UUID) | Primary lookup key |
+| `other_config:kubernetes_pv_name` | Kubernetes PV name | Informational |
+| `other_config:kubernetes_created_by` | Driver name | Identifies CSI-managed VDIs |
+
+---
+
+## Related documents
+
+- [Volume Handle and Volume ID in v0.3.0](volume-handle-and-volume-id-v0.3.0.md)
+- [Migration v0.3.0 to v0.4.0](../migrations/v0.3.0-to-v0.4.0.md)

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -60,9 +60,12 @@ in `AccessibleTopology`. This segment was removed for the following reasons:
   host is not only unnecessary but actively harmful for workload distribution.
 
 - **Local SRs** — For SRs local to a single host (raw `lvm`, `ext`, `btrfs`…) host
-  affinity is meaningful. However this use case requires a more nuanced mechanism
-  (dynamic SR topology via the CCM, not a static value in `NodeGetInfo`) and is not
-  yet implemented.
+  affinity is meaningful. The driver handles this via the `storageType: local`
+  StorageClass parameter: in `ControllerPublishVolume` the VDI is migrated to the
+  target host's local SR before being attached to the VM. Because migration changes
+  the VDI UUID, the PVC UID stored in `VDI.other_config` is used to re-locate the
+  VDI after VM live-migration. See the
+  [Local Storage reference](references/local-storage.md) for full details.
 
 ## Cross-pool migration restriction
 

--- a/examples/csi-app-local-storage.yaml
+++ b/examples/csi-app-local-storage.yaml
@@ -1,0 +1,79 @@
+# Example: Local storage dynamic volume provisioning
+#
+# The StorageClass sets `storageType: local`. This changes provisioning
+# behaviour in two ways compared to the default shared storage:
+#
+#   1. CreateVolume: the VDI is created on a local (non-shared) SR in the
+#      selected pool instead of the pool's DefaultSR.
+#   2. ControllerPublishVolume: before attaching the VDI to the target VM,
+#      the driver migrates it to the local SR of the host where the VM runs.
+#      If the VM is later rescheduled to a different host, the next
+#      ControllerPublishVolume call migrates the VDI to the new host's
+#      local SR automatically.
+#
+# When to use:
+#   - Workloads that benefit from local NVMe/SSD storage (low latency, high
+#     throughput) and can tolerate node affinity constraints.
+#   - Single-node or pinned workloads where live migration is not expected.
+#
+# Requirements:
+#   - volumeBindingMode: WaitForFirstConsumer  — the scheduler must pick a
+#     node before ControllerPublishVolume runs so the driver knows which
+#     host's local SR to target. Immediate binding is strongly discouraged.
+#   - Each host in the pool must have at least one local user SR that is
+#     plugged and not in maintenance mode.
+#   - Nodes must carry the topology.k8s.xenorchestra/pool_id label
+#     (set by the XenOrchestra CCM or the CSI node plugin's NodeGetInfo).
+#
+# Replace <xo-pool-uuid> with the UUID of your Xen Orchestra pool.
+#
+# Apply: kubectl apply -f csi-app-local-storage.yaml
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: xo-sc-local
+provisioner: csi.xenorchestra.vates.tech
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+parameters:
+  storageType: "local"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: xo-pvc-local
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: xo-sc-local
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: xo-app-local
+spec:
+  # affinity:
+  #   nodeAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #       nodeSelectorTerms:
+  #         - matchExpressions:
+  #             - key: kubernetes.io/hostname
+  #               operator: In
+  #               values:
+  #                 - "cp"
+  containers:
+    - name: app
+      image: busybox
+      command: [ "/bin/sh", "-c", "trap 'exit 0' TERM INT; while true; do sleep 2; done" ]
+      volumeMounts:
+        - mountPath: /data
+          name: storage
+  volumes:
+    - name: storage
+      persistentVolumeClaim:
+        claimName: xo-pvc-local

--- a/pkg/xenorchestra-csi/clients/helpers.go
+++ b/pkg/xenorchestra-csi/clients/helpers.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2025 Vates
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package clients
+
+import "fmt"
+
+// BuildVDINameLabel constructs the VDI.name_label for a new volume.
+// The format is "<prefix><volumeId>-<volumeName>" (e.g. "csi-12345678-90ab-cdef-pvc-xyz").
+// The volumeId is embedded so that GetVDIByVolumeId can fall back to searching
+// by name_label when other_config has been erased.
+func BuildVDINameLabel(prefix, volumeId, volumeName string) string {
+	return fmt.Sprintf("%s%s-%s", prefix, volumeId, volumeName)
+}
+
+// BuildVDINameDescription constructs the VDI.name_description for a new volume.
+// It appends "; pv-name=<volumeName>" to the standard description so operators
+// can identify the backing Kubernetes PV in the Xen Orchestra UI.
+// This field is not used for lookups.
+func BuildVDINameDescription(volumeName string) string {
+	return "VDI managed by the Kubernetes CSI; pv-name=" + volumeName
+}

--- a/pkg/xenorchestra-csi/clients/mock/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/mock/xoclient.go
@@ -104,6 +104,36 @@ func (mr *MockXoClientMockRecorder) DisconnectVBDFromVM(ctx, vdi, vmUUID any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisconnectVBDFromVM", reflect.TypeOf((*MockXoClient)(nil).DisconnectVBDFromVM), ctx, vdi, vmUUID)
 }
 
+// FindLocalSRForHost mocks base method.
+func (m *MockXoClient) FindLocalSRForHost(ctx context.Context, hostID uuid.UUID) (*payloads.StorageRepository, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindLocalSRForHost", ctx, hostID)
+	ret0, _ := ret[0].(*payloads.StorageRepository)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindLocalSRForHost indicates an expected call of FindLocalSRForHost.
+func (mr *MockXoClientMockRecorder) FindLocalSRForHost(ctx, hostID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLocalSRForHost", reflect.TypeOf((*MockXoClient)(nil).FindLocalSRForHost), ctx, hostID)
+}
+
+// FindLocalSRsForPool mocks base method.
+func (m *MockXoClient) FindLocalSRsForPool(ctx context.Context, poolID uuid.UUID) ([]*payloads.StorageRepository, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindLocalSRsForPool", ctx, poolID)
+	ret0, _ := ret[0].([]*payloads.StorageRepository)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindLocalSRsForPool indicates an expected call of FindLocalSRsForPool.
+func (mr *MockXoClientMockRecorder) FindLocalSRsForPool(ctx, poolID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLocalSRsForPool", reflect.TypeOf((*MockXoClient)(nil).FindLocalSRsForPool), ctx, poolID)
+}
+
 // FindVDIByVolumeName mocks base method.
 func (m *MockXoClient) FindVDIByVolumeName(ctx context.Context, volumeName string) (*payloads.VDI, string, error) {
 	m.ctrl.T.Helper()
@@ -205,6 +235,21 @@ func (m *MockXoClient) IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI)
 func (mr *MockXoClientMockRecorder) IsVDIUsedAnywhere(ctx, vdi any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVDIUsedAnywhere", reflect.TypeOf((*MockXoClient)(nil).IsVDIUsedAnywhere), ctx, vdi)
+}
+
+// MigrateVDIAndWait mocks base method.
+func (m *MockXoClient) MigrateVDIAndWait(ctx context.Context, vdiID, targetSRID uuid.UUID) (uuid.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MigrateVDIAndWait", ctx, vdiID, targetSRID)
+	ret0, _ := ret[0].(uuid.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MigrateVDIAndWait indicates an expected call of MigrateVDIAndWait.
+func (mr *MockXoClientMockRecorder) MigrateVDIAndWait(ctx, vdiID, targetSRID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateVDIAndWait", reflect.TypeOf((*MockXoClient)(nil).MigrateVDIAndWait), ctx, vdiID, targetSRID)
 }
 
 // PBD mocks base method.

--- a/pkg/xenorchestra-csi/clients/mock/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/mock/xoclient.go
@@ -75,9 +75,9 @@ func (mr *MockXoClientMockRecorder) ConnectVBDToVM(ctx, vbd any) *gomock.Call {
 }
 
 // CreateNewVolume mocks base method.
-func (m *MockXoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, diskName string, capacityBytes int64, volumeName, createdBy, clusterTag string) (uuid.UUID, uuid.UUID, error) {
+func (m *MockXoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, namePrefix string, capacityBytes int64, volumeName, createdBy, clusterTag string) (uuid.UUID, uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNewVolume", ctx, srID, diskName, capacityBytes, volumeName, createdBy, clusterTag)
+	ret := m.ctrl.Call(m, "CreateNewVolume", ctx, srID, namePrefix, capacityBytes, volumeName, createdBy, clusterTag)
 	ret0, _ := ret[0].(uuid.UUID)
 	ret1, _ := ret[1].(uuid.UUID)
 	ret2, _ := ret[2].(error)
@@ -85,9 +85,9 @@ func (m *MockXoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, disk
 }
 
 // CreateNewVolume indicates an expected call of CreateNewVolume.
-func (mr *MockXoClientMockRecorder) CreateNewVolume(ctx, srID, diskName, capacityBytes, volumeName, createdBy, clusterTag any) *gomock.Call {
+func (mr *MockXoClientMockRecorder) CreateNewVolume(ctx, srID, namePrefix, capacityBytes, volumeName, createdBy, clusterTag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewVolume", reflect.TypeOf((*MockXoClient)(nil).CreateNewVolume), ctx, srID, diskName, capacityBytes, volumeName, createdBy, clusterTag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewVolume", reflect.TypeOf((*MockXoClient)(nil).CreateNewVolume), ctx, srID, namePrefix, capacityBytes, volumeName, createdBy, clusterTag)
 }
 
 // DisconnectVBDFromVM mocks base method.

--- a/pkg/xenorchestra-csi/clients/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/xoclient.go
@@ -57,6 +57,18 @@ type XoClient interface {
 	// and remains stable across SR migrations.
 	// Returns ErrVolumeNotFound if no VDI matches, ErrVolumeIdAmbiguous if multiple match.
 	GetVDIByVolumeId(ctx context.Context, volumeId string) (*payloads.VDI, error)
+
+	// FindLocalSRForHost returns the first local (non-shared) user SR whose
+	// container is the given host. Returns an error if none is found.
+	FindLocalSRForHost(ctx context.Context, hostID uuid.UUID) (*payloads.StorageRepository, error)
+
+	// FindLocalSRsForPool returns all local (non-shared) user SRs belonging to
+	// the given pool. Returns an error if the API call fails or none are found.
+	FindLocalSRsForPool(ctx context.Context, poolID uuid.UUID) ([]*payloads.StorageRepository, error)
+
+	// MigrateVDIAndWait migrates vdiID to targetSRID and blocks until the task
+	// completes. Returns the new VDI UUID assigned by XAPI after migration.
+	MigrateVDIAndWait(ctx context.Context, vdiID uuid.UUID, targetSRID uuid.UUID) (uuid.UUID, error)
 }
 
 type xoClient struct {
@@ -204,15 +216,12 @@ func (c xoClient) IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI) ([]*
 
 // IsSRAttachedToHost checks that the given SR is connected (via a plugged PBD) to the given host.
 func (c xoClient) IsSRAttachedToHost(ctx context.Context, srID uuid.UUID, hostID uuid.UUID) error {
-	pbds, err := c.PBD().GetAll(ctx, 1, fmt.Sprintf("SR:%s host:%s", srID, hostID))
+	pbds, err := c.PBD().GetAll(ctx, 1, fmt.Sprintf("SR:%s host:%s attached?", srID, hostID))
 	if err != nil {
 		return fmt.Errorf("failed to list PBDs for SR %s on host %s: %w", srID, hostID, err)
 	}
 	if len(pbds) == 0 {
-		return fmt.Errorf("SR %s has no PBD for host %s; the SR may not be shared with this host", srID, hostID)
-	}
-	if !pbds[0].Attached {
-		return fmt.Errorf("SR %s is not connected to host %s (PBD %s is unplugged)", srID, hostID, pbds[0].ID)
+		return fmt.Errorf("SR %s is not connected to host %s (no plugged PBD found)", srID, hostID)
 	}
 	return nil
 }
@@ -288,4 +297,46 @@ func (c xoClient) FindVDIByVolumeName(ctx context.Context, volumeName string) (*
 	default:
 		return nil, "", fmt.Errorf("%w: volumeName=%s matched %d VDIs", ErrVolumeNameAmbiguous, volumeName, len(vdis))
 	}
+}
+
+func (c xoClient) FindLocalSRForHost(ctx context.Context, hostID uuid.UUID) (*payloads.StorageRepository, error) {
+	filter := fmt.Sprintf("content_type:user !shared? !inMaintenanceMode? $PBDs:length:>=1 $container:%s", hostID)
+	srs, err := c.SR().GetAll(ctx, 1, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list local SRs for host %s: %w", hostID, err)
+	}
+	if len(srs) == 0 {
+		return nil, fmt.Errorf("no local SR with a connected PBD found on host %s", hostID)
+	}
+	return srs[0], nil
+}
+
+func (c xoClient) FindLocalSRsForPool(ctx context.Context, poolID uuid.UUID) ([]*payloads.StorageRepository, error) {
+	filter := fmt.Sprintf("content_type:user !shared? !inMaintenanceMode? $PBDs:length:>=1 $pool:%s", poolID)
+	srs, err := c.SR().GetAll(ctx, 0, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list local SRs for pool %s: %w", poolID, err)
+	}
+	if len(srs) == 0 {
+		return nil, fmt.Errorf("no local SR with a connected PBD found in pool %s", poolID)
+	}
+	return srs, nil
+}
+
+func (c xoClient) MigrateVDIAndWait(ctx context.Context, vdiID uuid.UUID, targetSRID uuid.UUID) (uuid.UUID, error) {
+	taskID, err := c.VDI().Migrate(ctx, vdiID, targetSRID)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to start VDI migration (vdiID=%s targetSR=%s): %w", vdiID, targetSRID, err)
+	}
+	task, err := c.Task().Wait(ctx, taskID)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to wait for VDI migration task %s: %w", taskID, err)
+	}
+	if task.Status != payloads.Success {
+		return uuid.Nil, fmt.Errorf("VDI migration task %s finished with status %q: %s", taskID, task.Status, task.Result.Message)
+	}
+	if task.Result.ID == uuid.Nil {
+		return uuid.Nil, fmt.Errorf("VDI migration task %s succeeded but returned no new VDI UUID", taskID)
+	}
+	return task.Result.ID, nil
 }

--- a/pkg/xenorchestra-csi/clients/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/xoclient.go
@@ -38,7 +38,7 @@ type XoClient interface {
 	ConnectVBDToVM(ctx context.Context, vbd payloads.VBD) (*payloads.VBD, error)
 	DisconnectVBDFromVM(ctx context.Context, vdi payloads.VDI, vmUUID uuid.UUID) error
 	AttachVDIToVM(ctx context.Context, vdi payloads.VDI, vmUUID uuid.UUID) (*payloads.VBD, error)
-	CreateNewVolume(ctx context.Context, srID uuid.UUID, diskName string, capacityBytes int64, volumeName string, createdBy string, clusterTag string) (uuid.UUID, uuid.UUID, error)
+	CreateNewVolume(ctx context.Context, srID uuid.UUID, namePrefix string, capacityBytes int64, volumeName string, createdBy string, clusterTag string) (uuid.UUID, uuid.UUID, error)
 	WaitForVDIToBeFullyAttached(ctx context.Context, vbdID uuid.UUID) (*payloads.VBD, error)
 	IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI) ([]*payloads.VBD, error)
 	// FindVDIByVolumeName looks up a VDI by the Kubernetes PV name stored in
@@ -143,7 +143,7 @@ func (c xoClient) AttachVDIToVM(ctx context.Context, vdi payloads.VDI, vmUUID uu
 	return vbd, nil
 }
 
-func (c xoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, diskName string, capacityBytes int64, volumeName string, createdBy string, clusterTag string) (uuid.UUID, uuid.UUID, error) {
+func (c xoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, namePrefix string, capacityBytes int64, volumeName string, createdBy string, clusterTag string) (uuid.UUID, uuid.UUID, error) {
 	volumeId, err := uuid.NewV4()
 	if err != nil {
 		return uuid.Nil, uuid.Nil, fmt.Errorf("failed to generate volume ID UUID: %w", err)
@@ -157,9 +157,9 @@ func (c xoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, diskName 
 
 	vdiParams := payloads.VDICreateParams{
 		SRId:            srID,
-		NameLabel:       diskName,
+		NameLabel:       BuildVDINameLabel(namePrefix, volumeId.String(), volumeName),
 		VirtualSize:     capacityBytes,
-		NameDescription: "VDI managed by the Kubernetes CSI",
+		NameDescription: BuildVDINameDescription(volumeName),
 		OtherConfig:     otherConfig,
 	}
 	if clusterTag != "" {
@@ -275,7 +275,23 @@ func (c xoClient) GetVDIByVolumeId(ctx context.Context, volumeId string) (*paylo
 	}
 	switch len(vdis) {
 	case 0:
-		return nil, ErrVolumeNotFound
+		// Fallback: search by name_label containing the volumeId.
+		// This handles the case where other_config was erased (e.g. after a XO restore).
+		// NOTE: This should be removed in a future major release once we can be sure other_config is always preserved.
+		klog.V(2).InfoS("No VDI found with other_config volume ID, falling back to name_label search", "volumeId", volumeId)
+		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+		vdis, err = c.VDI().GetAll(ctx, 2, fallbackFilter)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list VDIs by name_label for volume ID %s: %w", volumeId, err)
+		}
+		switch len(vdis) {
+		case 0:
+			return nil, ErrVolumeNotFound
+		case 1:
+			return vdis[0], nil
+		default:
+			return nil, fmt.Errorf("%w: volumeId=%s matched %d VDIs via name_label fallback", ErrVolumeIdAmbiguous, volumeId, len(vdis))
+		}
 	case 1:
 		return vdis[0], nil
 	default:

--- a/pkg/xenorchestra-csi/clients/xoclient_test.go
+++ b/pkg/xenorchestra-csi/clients/xoclient_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright (c) 2026 Vates
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	v1 "github.com/vatesfr/xenorchestra-go-sdk/client"
+	"github.com/vatesfr/xenorchestra-go-sdk/pkg/payloads"
+	"github.com/vatesfr/xenorchestra-go-sdk/pkg/services/library"
+	xoLibMock "github.com/vatesfr/xenorchestra-go-sdk/pkg/services/library/mock"
+)
+
+// stubLibrary implements library.Library with only SR() wired; all other
+// methods panic to catch accidental calls in tests.
+type stubLibrary struct {
+	library.Library
+	sr   library.SR
+	vdi  library.VDI
+	task library.Task
+}
+
+func (s stubLibrary) SR() library.SR        { return s.sr }
+func (s stubLibrary) VDI() library.VDI      { return s.vdi }
+func (s stubLibrary) Task() library.Task    { return s.task }
+func (s stubLibrary) V1Client() v1.XOClient { panic("V1Client not expected in this test") }
+
+var (
+	hostUUID   = uuid.Must(uuid.FromString("aaaaaaaa-0000-0000-0000-000000000001"))
+	localSRID  = uuid.Must(uuid.FromString("bbbbbbbb-0000-0000-0000-000000000002"))
+	localSRID2 = uuid.Must(uuid.FromString("bbbbbbbb-0000-0000-0000-000000000003"))
+	poolUUID   = uuid.Must(uuid.FromString("eeeeeeee-0000-0000-0000-000000000005"))
+	vdiUUID    = uuid.Must(uuid.FromString("cccccccc-0000-0000-0000-000000000003"))
+	newVDIUUID = uuid.Must(uuid.FromString("dddddddd-0000-0000-0000-000000000004"))
+	taskID     = "task-abc-123"
+)
+
+func newClientWithMockSR(t *testing.T) (*xoClient, *xoLibMock.MockSR) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockSR := xoLibMock.NewMockSR(ctrl)
+	c := xoClient{Library: stubLibrary{sr: mockSR}}
+	return &c, mockSR
+}
+
+func newClientWithMockVDIAndTask(t *testing.T) (*xoClient, *xoLibMock.MockVDI, *xoLibMock.MockTask) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockVDI := xoLibMock.NewMockVDI(ctrl)
+	mockTask := xoLibMock.NewMockTask(ctrl)
+	c := xoClient{Library: stubLibrary{vdi: mockVDI, task: mockTask}}
+	return &c, mockVDI, mockTask
+}
+
+func expectedLocalSRFilter(hostID uuid.UUID) string {
+	return fmt.Sprintf("content_type:user !shared? !inMaintenanceMode? $PBDs:length:>=1 $container:%s", hostID)
+}
+
+func TestFindLocalSRForHost_ReturnsSR(t *testing.T) {
+	c, mockSR := newClientWithMockSR(t)
+
+	sr := &payloads.StorageRepository{ID: localSRID, Shared: false, ContentType: "user"}
+	mockSR.EXPECT().
+		GetAll(gomock.Any(), 1, expectedLocalSRFilter(hostUUID)).
+		Return([]*payloads.StorageRepository{sr}, nil)
+
+	got, err := c.FindLocalSRForHost(context.Background(), hostUUID)
+	require.NoError(t, err)
+	assert.Equal(t, sr, got)
+}
+
+func TestFindLocalSRForHost_NoSRFound(t *testing.T) {
+	c, mockSR := newClientWithMockSR(t)
+
+	mockSR.EXPECT().
+		GetAll(gomock.Any(), 1, expectedLocalSRFilter(hostUUID)).
+		Return([]*payloads.StorageRepository{}, nil)
+
+	_, err := c.FindLocalSRForHost(context.Background(), hostUUID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), hostUUID.String())
+}
+
+func TestFindLocalSRForHost_APIError(t *testing.T) {
+	c, mockSR := newClientWithMockSR(t)
+
+	apiErr := errors.New("connection refused")
+	mockSR.EXPECT().
+		GetAll(gomock.Any(), 1, expectedLocalSRFilter(hostUUID)).
+		Return(nil, apiErr)
+
+	_, err := c.FindLocalSRForHost(context.Background(), hostUUID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, apiErr)
+}
+
+func TestMigrateVDIAndWait_Success(t *testing.T) {
+	c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
+
+	mockVDI.EXPECT().
+		Migrate(gomock.Any(), vdiUUID, localSRID).
+		Return(taskID, nil)
+	mockTask.EXPECT().
+		Wait(gomock.Any(), taskID).
+		Return(&payloads.Task{
+			Status: payloads.Success,
+			Result: payloads.Result{ID: newVDIUUID},
+		}, nil)
+
+	got, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+	require.NoError(t, err)
+	assert.Equal(t, newVDIUUID, got)
+}
+
+func TestMigrateVDIAndWait_MigrateError(t *testing.T) {
+	c, mockVDI, _ := newClientWithMockVDIAndTask(t)
+
+	migrateErr := errors.New("SR not found")
+	mockVDI.EXPECT().
+		Migrate(gomock.Any(), vdiUUID, localSRID).
+		Return("", migrateErr)
+
+	_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, migrateErr)
+}
+
+func TestMigrateVDIAndWait_TaskWaitError(t *testing.T) {
+	c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
+
+	waitErr := errors.New("context deadline exceeded")
+	mockVDI.EXPECT().
+		Migrate(gomock.Any(), vdiUUID, localSRID).
+		Return(taskID, nil)
+	mockTask.EXPECT().
+		Wait(gomock.Any(), taskID).
+		Return(nil, waitErr)
+
+	_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, waitErr)
+}
+
+func TestMigrateVDIAndWait_TaskFailed(t *testing.T) {
+	c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
+
+	mockVDI.EXPECT().
+		Migrate(gomock.Any(), vdiUUID, localSRID).
+		Return(taskID, nil)
+	mockTask.EXPECT().
+		Wait(gomock.Any(), taskID).
+		Return(&payloads.Task{
+			Status: payloads.Failure,
+			Result: payloads.Result{Message: "random failure message from XAPI"},
+		}, nil)
+
+	_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), string(payloads.Failure))
+	assert.Contains(t, err.Error(), "random failure message from XAPI")
+}
+
+func TestMigrateVDIAndWait_ResultNilID(t *testing.T) {
+	c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
+
+	mockVDI.EXPECT().
+		Migrate(gomock.Any(), vdiUUID, localSRID).
+		Return(taskID, nil)
+	mockTask.EXPECT().
+		Wait(gomock.Any(), taskID).
+		Return(&payloads.Task{
+			Status: payloads.Success,
+			Result: payloads.Result{ID: uuid.Nil},
+		}, nil)
+
+	_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+	require.Error(t, err)
+}
+
+func expectedLocalSRsForPoolFilter(poolID uuid.UUID) string {
+	return fmt.Sprintf("content_type:user !shared? !inMaintenanceMode? $PBDs:length:>=1 $pool:%s", poolID)
+}
+
+func TestFindLocalSRsForPool_ReturnsSRs(t *testing.T) {
+	c, mockSR := newClientWithMockSR(t)
+
+	sr1 := &payloads.StorageRepository{ID: localSRID}
+	sr2 := &payloads.StorageRepository{ID: localSRID2}
+	mockSR.EXPECT().
+		GetAll(gomock.Any(), 0, expectedLocalSRsForPoolFilter(poolUUID)).
+		Return([]*payloads.StorageRepository{sr1, sr2}, nil)
+
+	got, err := c.FindLocalSRsForPool(context.Background(), poolUUID)
+	require.NoError(t, err)
+	assert.Equal(t, []*payloads.StorageRepository{sr1, sr2}, got)
+}
+
+func TestFindLocalSRsForPool_NoSRFound(t *testing.T) {
+	c, mockSR := newClientWithMockSR(t)
+
+	mockSR.EXPECT().
+		GetAll(gomock.Any(), 0, expectedLocalSRsForPoolFilter(poolUUID)).
+		Return([]*payloads.StorageRepository{}, nil)
+
+	_, err := c.FindLocalSRsForPool(context.Background(), poolUUID)
+	require.Error(t, err)
+}
+
+func TestFindLocalSRsForPool_APIError(t *testing.T) {
+	c, mockSR := newClientWithMockSR(t)
+
+	apiErr := errors.New("connection refused")
+	mockSR.EXPECT().
+		GetAll(gomock.Any(), 0, expectedLocalSRsForPoolFilter(poolUUID)).
+		Return(nil, apiErr)
+
+	_, err := c.FindLocalSRsForPool(context.Background(), poolUUID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, apiErr)
+}

--- a/pkg/xenorchestra-csi/clients/xoclient_test.go
+++ b/pkg/xenorchestra-csi/clients/xoclient_test.go
@@ -93,299 +93,307 @@ func expectedLocalSRsForPoolFilter(poolID uuid.UUID) string {
 // FindLocalSRForHost
 // ---------------------------------------------------------------------------
 
-func TestFindLocalSRForHost_ReturnsSR(t *testing.T) {
-	c, mockSR := newClientWithMockSR(t)
+func TestFindLocalSRForHost(t *testing.T) {
+	t.Run("ReturnsSR", func(t *testing.T) {
+		c, mockSR := newClientWithMockSR(t)
 
-	sr := &payloads.StorageRepository{ID: localSRID, Shared: false, ContentType: "user"}
-	mockSR.EXPECT().
-		GetAll(gomock.Any(), 1, expectedLocalSRFilter(hostUUID)).
-		Return([]*payloads.StorageRepository{sr}, nil)
+		sr := &payloads.StorageRepository{ID: localSRID, Shared: false, ContentType: "user"}
+		mockSR.EXPECT().
+			GetAll(gomock.Any(), 1, expectedLocalSRFilter(hostUUID)).
+			Return([]*payloads.StorageRepository{sr}, nil)
 
-	got, err := c.FindLocalSRForHost(context.Background(), hostUUID)
-	require.NoError(t, err)
-	assert.Equal(t, sr, got)
-}
+		got, err := c.FindLocalSRForHost(context.Background(), hostUUID)
+		require.NoError(t, err)
+		assert.Equal(t, sr, got)
+	})
 
-func TestFindLocalSRForHost_NoSRFound(t *testing.T) {
-	c, mockSR := newClientWithMockSR(t)
+	t.Run("NoSRFound", func(t *testing.T) {
+		c, mockSR := newClientWithMockSR(t)
 
-	mockSR.EXPECT().
-		GetAll(gomock.Any(), 1, expectedLocalSRFilter(hostUUID)).
-		Return([]*payloads.StorageRepository{}, nil)
+		mockSR.EXPECT().
+			GetAll(gomock.Any(), 1, expectedLocalSRFilter(hostUUID)).
+			Return([]*payloads.StorageRepository{}, nil)
 
-	_, err := c.FindLocalSRForHost(context.Background(), hostUUID)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), hostUUID.String())
-}
+		_, err := c.FindLocalSRForHost(context.Background(), hostUUID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), hostUUID.String())
+	})
 
-func TestFindLocalSRForHost_APIError(t *testing.T) {
-	c, mockSR := newClientWithMockSR(t)
+	t.Run("APIError", func(t *testing.T) {
+		c, mockSR := newClientWithMockSR(t)
 
-	apiErr := errors.New("connection refused")
-	mockSR.EXPECT().
-		GetAll(gomock.Any(), 1, expectedLocalSRFilter(hostUUID)).
-		Return(nil, apiErr)
+		apiErr := errors.New("connection refused")
+		mockSR.EXPECT().
+			GetAll(gomock.Any(), 1, expectedLocalSRFilter(hostUUID)).
+			Return(nil, apiErr)
 
-	_, err := c.FindLocalSRForHost(context.Background(), hostUUID)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, apiErr)
+		_, err := c.FindLocalSRForHost(context.Background(), hostUUID)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, apiErr)
+	})
 }
 
 // ---------------------------------------------------------------------------
 // MigrateVDIAndWait
 // ---------------------------------------------------------------------------
 
-func TestMigrateVDIAndWait_Success(t *testing.T) {
-	c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
+func TestMigrateVDIAndWait(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
 
-	mockVDI.EXPECT().
-		Migrate(gomock.Any(), vdiUUID, localSRID).
-		Return(taskID, nil)
-	mockTask.EXPECT().
-		Wait(gomock.Any(), taskID).
-		Return(&payloads.Task{
-			Status: payloads.Success,
-			Result: payloads.Result{ID: newVDIUUID},
-		}, nil)
+		mockVDI.EXPECT().
+			Migrate(gomock.Any(), vdiUUID, localSRID).
+			Return(taskID, nil)
+		mockTask.EXPECT().
+			Wait(gomock.Any(), taskID).
+			Return(&payloads.Task{
+				Status: payloads.Success,
+				Result: payloads.Result{ID: newVDIUUID},
+			}, nil)
 
-	got, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
-	require.NoError(t, err)
-	assert.Equal(t, newVDIUUID, got)
-}
+		got, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+		require.NoError(t, err)
+		assert.Equal(t, newVDIUUID, got)
+	})
 
-func TestMigrateVDIAndWait_MigrateError(t *testing.T) {
-	c, mockVDI, _ := newClientWithMockVDIAndTask(t)
+	t.Run("MigrateError", func(t *testing.T) {
+		c, mockVDI, _ := newClientWithMockVDIAndTask(t)
 
-	migrateErr := errors.New("SR not found")
-	mockVDI.EXPECT().
-		Migrate(gomock.Any(), vdiUUID, localSRID).
-		Return("", migrateErr)
+		migrateErr := errors.New("SR not found")
+		mockVDI.EXPECT().
+			Migrate(gomock.Any(), vdiUUID, localSRID).
+			Return("", migrateErr)
 
-	_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, migrateErr)
-}
+		_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, migrateErr)
+	})
 
-func TestMigrateVDIAndWait_TaskWaitError(t *testing.T) {
-	c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
+	t.Run("TaskWaitError", func(t *testing.T) {
+		c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
 
-	waitErr := errors.New("context deadline exceeded")
-	mockVDI.EXPECT().
-		Migrate(gomock.Any(), vdiUUID, localSRID).
-		Return(taskID, nil)
-	mockTask.EXPECT().
-		Wait(gomock.Any(), taskID).
-		Return(nil, waitErr)
+		waitErr := errors.New("context deadline exceeded")
+		mockVDI.EXPECT().
+			Migrate(gomock.Any(), vdiUUID, localSRID).
+			Return(taskID, nil)
+		mockTask.EXPECT().
+			Wait(gomock.Any(), taskID).
+			Return(nil, waitErr)
 
-	_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, waitErr)
-}
+		_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, waitErr)
+	})
 
-func TestMigrateVDIAndWait_TaskFailed(t *testing.T) {
-	c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
+	t.Run("TaskFailed", func(t *testing.T) {
+		c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
 
-	mockVDI.EXPECT().
-		Migrate(gomock.Any(), vdiUUID, localSRID).
-		Return(taskID, nil)
-	mockTask.EXPECT().
-		Wait(gomock.Any(), taskID).
-		Return(&payloads.Task{
-			Status: payloads.Failure,
-			Result: payloads.Result{Message: "random failure message from XAPI"},
-		}, nil)
+		mockVDI.EXPECT().
+			Migrate(gomock.Any(), vdiUUID, localSRID).
+			Return(taskID, nil)
+		mockTask.EXPECT().
+			Wait(gomock.Any(), taskID).
+			Return(&payloads.Task{
+				Status: payloads.Failure,
+				Result: payloads.Result{Message: "random failure message from XAPI"},
+			}, nil)
 
-	_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), string(payloads.Failure))
-	assert.Contains(t, err.Error(), "random failure message from XAPI")
-}
+		_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), string(payloads.Failure))
+		assert.Contains(t, err.Error(), "random failure message from XAPI")
+	})
 
-func TestMigrateVDIAndWait_ResultNilID(t *testing.T) {
-	c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
+	t.Run("ResultNilID", func(t *testing.T) {
+		c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
 
-	mockVDI.EXPECT().
-		Migrate(gomock.Any(), vdiUUID, localSRID).
-		Return(taskID, nil)
-	mockTask.EXPECT().
-		Wait(gomock.Any(), taskID).
-		Return(&payloads.Task{
-			Status: payloads.Success,
-			Result: payloads.Result{ID: uuid.Nil},
-		}, nil)
+		mockVDI.EXPECT().
+			Migrate(gomock.Any(), vdiUUID, localSRID).
+			Return(taskID, nil)
+		mockTask.EXPECT().
+			Wait(gomock.Any(), taskID).
+			Return(&payloads.Task{
+				Status: payloads.Success,
+				Result: payloads.Result{ID: uuid.Nil},
+			}, nil)
 
-	_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
-	require.Error(t, err)
+		_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+		require.Error(t, err)
+	})
 }
 
 // ---------------------------------------------------------------------------
 // GetVDIByVolumeId
 // ---------------------------------------------------------------------------
 
-func TestGetVDIByVolumeId_FoundViaOtherConfig(t *testing.T) {
-	c, mockVDI := newClientWithMockVDI(t)
+func TestGetVDIByVolumeId(t *testing.T) {
+	t.Run("FoundViaOtherConfig", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
 
-	volumeId := "aaaaaaaa-0000-0000-0000-000000000010"
-	vdi := &payloads.VDI{
-		ID: vdiUUID,
-		OtherConfig: map[string]string{
-			VDIOtherConfigKeyVolumeId: volumeId,
-		},
-	}
-	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, primaryFilter).
-		Return([]*payloads.VDI{vdi}, nil)
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000010"
+		vdi := &payloads.VDI{
+			ID: vdiUUID,
+			OtherConfig: map[string]string{
+				VDIOtherConfigKeyVolumeId: volumeId,
+			},
+		}
+		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return([]*payloads.VDI{vdi}, nil)
 
-	got, err := c.GetVDIByVolumeId(context.Background(), volumeId)
-	require.NoError(t, err)
-	assert.Equal(t, vdi, got)
-}
+		got, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.NoError(t, err)
+		assert.Equal(t, vdi, got)
+	})
 
-func TestGetVDIByVolumeId_FallbackViaNameLabel(t *testing.T) {
-	c, mockVDI := newClientWithMockVDI(t)
+	t.Run("FallbackViaNameLabel", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
 
-	volumeId := "aaaaaaaa-0000-0000-0000-000000000011"
-	vdi := &payloads.VDI{
-		ID:        vdiUUID,
-		NameLabel: "csi-" + volumeId + "-pvc-xyz",
-	}
-	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
-	fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, primaryFilter).
-		Return([]*payloads.VDI{}, nil)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, fallbackFilter).
-		Return([]*payloads.VDI{vdi}, nil)
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000011"
+		vdi := &payloads.VDI{
+			ID:        vdiUUID,
+			NameLabel: "csi-" + volumeId + "-pvc-xyz",
+		}
+		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, fallbackFilter).
+			Return([]*payloads.VDI{vdi}, nil)
 
-	got, err := c.GetVDIByVolumeId(context.Background(), volumeId)
-	require.NoError(t, err)
-	assert.Equal(t, vdi, got)
-}
+		got, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.NoError(t, err)
+		assert.Equal(t, vdi, got)
+	})
 
-func TestGetVDIByVolumeId_NotFoundInBothLookups(t *testing.T) {
-	c, mockVDI := newClientWithMockVDI(t)
+	t.Run("NotFoundInBothLookups", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
 
-	volumeId := "aaaaaaaa-0000-0000-0000-000000000012"
-	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
-	fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, primaryFilter).
-		Return([]*payloads.VDI{}, nil)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, fallbackFilter).
-		Return([]*payloads.VDI{}, nil)
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000012"
+		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, fallbackFilter).
+			Return([]*payloads.VDI{}, nil)
 
-	_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrVolumeNotFound)
-}
+		_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrVolumeNotFound)
+	})
 
-func TestGetVDIByVolumeId_AmbiguousViaOtherConfig(t *testing.T) {
-	c, mockVDI := newClientWithMockVDI(t)
+	t.Run("AmbiguousViaOtherConfig", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
 
-	volumeId := "aaaaaaaa-0000-0000-0000-000000000013"
-	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, primaryFilter).
-		Return([]*payloads.VDI{{ID: vdiUUID}, {ID: newVDIUUID}}, nil)
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000013"
+		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return([]*payloads.VDI{{ID: vdiUUID}, {ID: newVDIUUID}}, nil)
 
-	_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrVolumeIdAmbiguous)
-}
+		_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrVolumeIdAmbiguous)
+	})
 
-func TestGetVDIByVolumeId_AmbiguousViaNameLabelFallback(t *testing.T) {
-	c, mockVDI := newClientWithMockVDI(t)
+	t.Run("AmbiguousViaNameLabelFallback", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
 
-	volumeId := "aaaaaaaa-0000-0000-0000-000000000014"
-	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
-	fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, primaryFilter).
-		Return([]*payloads.VDI{}, nil)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, fallbackFilter).
-		Return([]*payloads.VDI{{ID: vdiUUID}, {ID: newVDIUUID}}, nil)
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000014"
+		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, fallbackFilter).
+			Return([]*payloads.VDI{{ID: vdiUUID}, {ID: newVDIUUID}}, nil)
 
-	_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrVolumeIdAmbiguous)
-}
+		_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrVolumeIdAmbiguous)
+	})
 
-func TestGetVDIByVolumeId_PrimaryAPIError(t *testing.T) {
-	c, mockVDI := newClientWithMockVDI(t)
+	t.Run("PrimaryAPIError", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
 
-	volumeId := "aaaaaaaa-0000-0000-0000-000000000015"
-	apiErr := errors.New("connection refused")
-	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, primaryFilter).
-		Return(nil, apiErr)
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000015"
+		apiErr := errors.New("connection refused")
+		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return(nil, apiErr)
 
-	_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, apiErr)
-}
+		_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, apiErr)
+	})
 
-func TestGetVDIByVolumeId_FallbackAPIError(t *testing.T) {
-	c, mockVDI := newClientWithMockVDI(t)
+	t.Run("FallbackAPIError", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
 
-	volumeId := "aaaaaaaa-0000-0000-0000-000000000016"
-	apiErr := errors.New("timeout")
-	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
-	fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, primaryFilter).
-		Return([]*payloads.VDI{}, nil)
-	mockVDI.EXPECT().
-		GetAll(gomock.Any(), 2, fallbackFilter).
-		Return(nil, apiErr)
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000016"
+		apiErr := errors.New("timeout")
+		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, fallbackFilter).
+			Return(nil, apiErr)
 
-	_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, apiErr)
+		_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, apiErr)
+	})
 }
 
 // ---------------------------------------------------------------------------
 // FindLocalSRsForPool
 // ---------------------------------------------------------------------------
 
-func TestFindLocalSRsForPool_ReturnsSRs(t *testing.T) {
-	c, mockSR := newClientWithMockSR(t)
+func TestFindLocalSRsForPool(t *testing.T) {
+	t.Run("ReturnsSRs", func(t *testing.T) {
+		c, mockSR := newClientWithMockSR(t)
 
-	sr1 := &payloads.StorageRepository{ID: localSRID}
-	sr2 := &payloads.StorageRepository{ID: localSRID2}
-	mockSR.EXPECT().
-		GetAll(gomock.Any(), 0, expectedLocalSRsForPoolFilter(poolUUID)).
-		Return([]*payloads.StorageRepository{sr1, sr2}, nil)
+		sr1 := &payloads.StorageRepository{ID: localSRID}
+		sr2 := &payloads.StorageRepository{ID: localSRID2}
+		mockSR.EXPECT().
+			GetAll(gomock.Any(), 0, expectedLocalSRsForPoolFilter(poolUUID)).
+			Return([]*payloads.StorageRepository{sr1, sr2}, nil)
 
-	got, err := c.FindLocalSRsForPool(context.Background(), poolUUID)
-	require.NoError(t, err)
-	assert.Equal(t, []*payloads.StorageRepository{sr1, sr2}, got)
-}
+		got, err := c.FindLocalSRsForPool(context.Background(), poolUUID)
+		require.NoError(t, err)
+		assert.Equal(t, []*payloads.StorageRepository{sr1, sr2}, got)
+	})
 
-func TestFindLocalSRsForPool_NoSRFound(t *testing.T) {
-	c, mockSR := newClientWithMockSR(t)
+	t.Run("NoSRFound", func(t *testing.T) {
+		c, mockSR := newClientWithMockSR(t)
 
-	mockSR.EXPECT().
-		GetAll(gomock.Any(), 0, expectedLocalSRsForPoolFilter(poolUUID)).
-		Return([]*payloads.StorageRepository{}, nil)
+		mockSR.EXPECT().
+			GetAll(gomock.Any(), 0, expectedLocalSRsForPoolFilter(poolUUID)).
+			Return([]*payloads.StorageRepository{}, nil)
 
-	_, err := c.FindLocalSRsForPool(context.Background(), poolUUID)
-	require.Error(t, err)
-}
+		_, err := c.FindLocalSRsForPool(context.Background(), poolUUID)
+		require.Error(t, err)
+	})
 
-func TestFindLocalSRsForPool_APIError(t *testing.T) {
-	c, mockSR := newClientWithMockSR(t)
+	t.Run("APIError", func(t *testing.T) {
+		c, mockSR := newClientWithMockSR(t)
 
-	apiErr := errors.New("connection refused")
-	mockSR.EXPECT().
-		GetAll(gomock.Any(), 0, expectedLocalSRsForPoolFilter(poolUUID)).
-		Return(nil, apiErr)
+		apiErr := errors.New("connection refused")
+		mockSR.EXPECT().
+			GetAll(gomock.Any(), 0, expectedLocalSRsForPoolFilter(poolUUID)).
+			Return(nil, apiErr)
 
-	_, err := c.FindLocalSRsForPool(context.Background(), poolUUID)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, apiErr)
+		_, err := c.FindLocalSRsForPool(context.Background(), poolUUID)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, apiErr)
+	})
 }

--- a/pkg/xenorchestra-csi/clients/xoclient_test.go
+++ b/pkg/xenorchestra-csi/clients/xoclient_test.go
@@ -64,6 +64,14 @@ func newClientWithMockSR(t *testing.T) (*xoClient, *xoLibMock.MockSR) {
 	return &c, mockSR
 }
 
+func newClientWithMockVDI(t *testing.T) (*xoClient, *xoLibMock.MockVDI) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockVDI := xoLibMock.NewMockVDI(ctrl)
+	c := xoClient{Library: stubLibrary{vdi: mockVDI}}
+	return &c, mockVDI
+}
+
 func newClientWithMockVDIAndTask(t *testing.T) (*xoClient, *xoLibMock.MockVDI, *xoLibMock.MockTask) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
@@ -76,6 +84,14 @@ func newClientWithMockVDIAndTask(t *testing.T) (*xoClient, *xoLibMock.MockVDI, *
 func expectedLocalSRFilter(hostID uuid.UUID) string {
 	return fmt.Sprintf("content_type:user !shared? !inMaintenanceMode? $PBDs:length:>=1 $container:%s", hostID)
 }
+
+func expectedLocalSRsForPoolFilter(poolID uuid.UUID) string {
+	return fmt.Sprintf("content_type:user !shared? !inMaintenanceMode? $PBDs:length:>=1 $pool:%s", poolID)
+}
+
+// ---------------------------------------------------------------------------
+// FindLocalSRForHost
+// ---------------------------------------------------------------------------
 
 func TestFindLocalSRForHost_ReturnsSR(t *testing.T) {
 	c, mockSR := newClientWithMockSR(t)
@@ -114,6 +130,10 @@ func TestFindLocalSRForHost_APIError(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, apiErr)
 }
+
+// ---------------------------------------------------------------------------
+// MigrateVDIAndWait
+// ---------------------------------------------------------------------------
 
 func TestMigrateVDIAndWait_Success(t *testing.T) {
 	c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
@@ -198,9 +218,139 @@ func TestMigrateVDIAndWait_ResultNilID(t *testing.T) {
 	require.Error(t, err)
 }
 
-func expectedLocalSRsForPoolFilter(poolID uuid.UUID) string {
-	return fmt.Sprintf("content_type:user !shared? !inMaintenanceMode? $PBDs:length:>=1 $pool:%s", poolID)
+// ---------------------------------------------------------------------------
+// GetVDIByVolumeId
+// ---------------------------------------------------------------------------
+
+func TestGetVDIByVolumeId_FoundViaOtherConfig(t *testing.T) {
+	c, mockVDI := newClientWithMockVDI(t)
+
+	volumeId := "aaaaaaaa-0000-0000-0000-000000000010"
+	vdi := &payloads.VDI{
+		ID: vdiUUID,
+		OtherConfig: map[string]string{
+			VDIOtherConfigKeyVolumeId: volumeId,
+		},
+	}
+	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, primaryFilter).
+		Return([]*payloads.VDI{vdi}, nil)
+
+	got, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+	require.NoError(t, err)
+	assert.Equal(t, vdi, got)
 }
+
+func TestGetVDIByVolumeId_FallbackViaNameLabel(t *testing.T) {
+	c, mockVDI := newClientWithMockVDI(t)
+
+	volumeId := "aaaaaaaa-0000-0000-0000-000000000011"
+	vdi := &payloads.VDI{
+		ID:        vdiUUID,
+		NameLabel: "csi-" + volumeId + "-pvc-xyz",
+	}
+	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+	fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, primaryFilter).
+		Return([]*payloads.VDI{}, nil)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, fallbackFilter).
+		Return([]*payloads.VDI{vdi}, nil)
+
+	got, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+	require.NoError(t, err)
+	assert.Equal(t, vdi, got)
+}
+
+func TestGetVDIByVolumeId_NotFoundInBothLookups(t *testing.T) {
+	c, mockVDI := newClientWithMockVDI(t)
+
+	volumeId := "aaaaaaaa-0000-0000-0000-000000000012"
+	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+	fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, primaryFilter).
+		Return([]*payloads.VDI{}, nil)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, fallbackFilter).
+		Return([]*payloads.VDI{}, nil)
+
+	_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrVolumeNotFound)
+}
+
+func TestGetVDIByVolumeId_AmbiguousViaOtherConfig(t *testing.T) {
+	c, mockVDI := newClientWithMockVDI(t)
+
+	volumeId := "aaaaaaaa-0000-0000-0000-000000000013"
+	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, primaryFilter).
+		Return([]*payloads.VDI{{ID: vdiUUID}, {ID: newVDIUUID}}, nil)
+
+	_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrVolumeIdAmbiguous)
+}
+
+func TestGetVDIByVolumeId_AmbiguousViaNameLabelFallback(t *testing.T) {
+	c, mockVDI := newClientWithMockVDI(t)
+
+	volumeId := "aaaaaaaa-0000-0000-0000-000000000014"
+	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+	fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, primaryFilter).
+		Return([]*payloads.VDI{}, nil)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, fallbackFilter).
+		Return([]*payloads.VDI{{ID: vdiUUID}, {ID: newVDIUUID}}, nil)
+
+	_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrVolumeIdAmbiguous)
+}
+
+func TestGetVDIByVolumeId_PrimaryAPIError(t *testing.T) {
+	c, mockVDI := newClientWithMockVDI(t)
+
+	volumeId := "aaaaaaaa-0000-0000-0000-000000000015"
+	apiErr := errors.New("connection refused")
+	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, primaryFilter).
+		Return(nil, apiErr)
+
+	_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, apiErr)
+}
+
+func TestGetVDIByVolumeId_FallbackAPIError(t *testing.T) {
+	c, mockVDI := newClientWithMockVDI(t)
+
+	volumeId := "aaaaaaaa-0000-0000-0000-000000000016"
+	apiErr := errors.New("timeout")
+	primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+	fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, primaryFilter).
+		Return([]*payloads.VDI{}, nil)
+	mockVDI.EXPECT().
+		GetAll(gomock.Any(), 2, fallbackFilter).
+		Return(nil, apiErr)
+
+	_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, apiErr)
+}
+
+// ---------------------------------------------------------------------------
+// FindLocalSRsForPool
+// ---------------------------------------------------------------------------
 
 func TestFindLocalSRsForPool_ReturnsSRs(t *testing.T) {
 	c, mockSR := newClientWithMockSR(t)

--- a/pkg/xenorchestra-csi/constants.go
+++ b/pkg/xenorchestra-csi/constants.go
@@ -49,4 +49,23 @@ const (
 	// VolumeContextKeyPoolName is the key in the PV's volumeAttributes (CSI VolumeContext)
 	// that stores the human-readable name of the Xen Orchestra pool.
 	VolumeContextKeyPoolName = "poolName"
+
+	// ParameterStorageType is an optional StorageClass parameter.
+	// Valid values: "shared" (default) or "local".
+	// - "shared": VDI is created on pool.DefaultSR and used as-is (current behavior).
+	// - "local":  VDI is created on random local SR of the pool at provision time, then migrated
+	//             to the target host's local SR in ControllerPublishVolume before
+	//             being attached to the VM.
+	ParameterStorageType = "storageType"
+
+	// StorageTypeShared is the default storageType: use pool shared storage.
+	StorageTypeShared = "shared"
+
+	// StorageTypeLocal migrates the VDI to the target host's local SR in
+	// ControllerPublishVolume before attaching.
+	StorageTypeLocal = "local"
+
+	// VolumeContextKeyStorageType carries the storageType value through the CSI
+	// lifecycle (CreateVolume → ControllerPublishVolume).
+	VolumeContextKeyStorageType = "storageType"
 )

--- a/pkg/xenorchestra-csi/constants.go
+++ b/pkg/xenorchestra-csi/constants.go
@@ -23,8 +23,8 @@ const (
 	// pool's DefaultSR as the target storage repository.
 	ParameterPoolID = "poolId"
 
-	// DefaultVDINamePrefix is prepended to the Kubernetes volume name when
-	// constructing the VDI name label in Xen Orchestra. Override it at
+	// DefaultVDINamePrefix is prepended to the VDI name label in Xen Orchestra.
+	// See BuildVDINameLabel for the full naming format. Override it at
 	// driver startup with the --vdi-name-prefix flag.
 	DefaultVDINamePrefix = "csi-"
 

--- a/pkg/xenorchestra-csi/controllerserver.go
+++ b/pkg/xenorchestra-csi/controllerserver.go
@@ -138,6 +138,35 @@ func (driver *xenorchestraCSIDriver) ControllerPublishVolume(ctx context.Context
 		return nil, status.Errorf(codes.FailedPrecondition, "cannot attach VDI from pool %s to VM in pool %s", vdi.PoolID, nodeVM.PoolID)
 	}
 
+	// For local storage, migrate the VDI to the host's local SR if needed.
+	if req.GetVolumeContext()[VolumeContextKeyStorageType] == StorageTypeLocal {
+		localSR, err := driver.xoClient.FindLocalSRForHost(ctx, nodeVM.Container)
+		if err != nil {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"no local SR found for host %s: %v", nodeVM.Container, err)
+		}
+		if vdi.SR != localSR.ID {
+			klog.V(2).InfoS("Migrating VDI to local SR",
+				"vdiID", vdi.ID, "fromSR", vdi.SR, "toSR", localSR.ID)
+			newVDIUUID, err := driver.xoClient.MigrateVDIAndWait(ctx, vdi.ID, localSR.ID)
+			if err != nil {
+				klog.ErrorS(err, "Failed to migrate VDI to local SR", "vdiID", vdi.ID, "localSRID", localSR.ID)
+				return nil, status.Errorf(codes.Internal,
+					"failed to migrate VDI %s to local SR %s: %v", vdi.ID, localSR.ID, err)
+			}
+			vdi, err = driver.xoClient.VDI().Get(ctx, newVDIUUID)
+			if err != nil {
+				klog.ErrorS(err, "Failed to fetch VDI after migration", "newVDIID", newVDIUUID)
+				return nil, status.Errorf(codes.Internal,
+					"failed to fetch VDI after migration (newUUID=%s): %v", newVDIUUID, err)
+			}
+			klog.V(2).InfoS("VDI migrated successfully", "newVDIID", vdi.ID, "srID", localSR.ID)
+		} else {
+			klog.V(4).InfoS("VDI already on correct local SR, skipping migration",
+				"vdiID", vdi.ID, "srID", localSR.ID)
+		}
+	}
+
 	// Verify the SR is reachable from the host where the VM is running before attempting
 	// to attach or connect any VBD.
 	if err := driver.xoClient.IsSRAttachedToHost(ctx, vdi.SR, nodeVM.Container); err != nil {
@@ -301,6 +330,15 @@ func (driver *xenorchestraCSIDriver) CreateVolume(ctx context.Context, req *csi.
 	poolIDStr, hasPoolParam := params[ParameterPoolID]
 	ar := req.GetAccessibilityRequirements()
 
+	storageType := params[ParameterStorageType]
+	if storageType == "" {
+		storageType = StorageTypeShared
+	}
+	if storageType != StorageTypeShared && storageType != StorageTypeLocal {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"invalid storageType %q: must be %q or %q", storageType, StorageTypeShared, StorageTypeLocal)
+	}
+
 	var pool *payloads.Pool
 	var sr *payloads.StorageRepository
 
@@ -338,6 +376,19 @@ func (driver *xenorchestraCSIDriver) CreateVolume(ctx context.Context, req *csi.
 
 	klog.V(5).InfoS("Using pool and SR", "poolID", pool.ID, "srID", sr.ID)
 
+	// For local storage, override the SR with one of the pool's local SRs so
+	// the VDI lands on local storage from the start rather than on the shared
+	// DefaultSR. That will help avoid an extra migration step in the common case
+	// where the volume is created and attached to the same node.
+	if storageType == StorageTypeLocal {
+		localSRs, err := driver.xoClient.FindLocalSRsForPool(ctx, pool.ID)
+		if err != nil {
+			return nil, status.Errorf(codes.FailedPrecondition, "no local SR available in pool %s: %v", pool.ID, err)
+		}
+		sr = localSRs[0]
+		klog.V(4).InfoS("Local storageType: using local SR for initial VDI creation", "poolID", pool.ID, "srID", sr.ID)
+	}
+
 	// Idempotency check: return the existing VDI if one was already created for this PV name.
 	existingVDI, existingId, err := driver.xoClient.FindVDIByVolumeName(ctx, volumeName)
 	if err != nil {
@@ -362,7 +413,7 @@ func (driver *xenorchestraCSIDriver) CreateVolume(ctx context.Context, req *csi.
 				VolumeId:           existingId,
 				CapacityBytes:      capacityBytes,
 				AccessibleTopology: driver.buildAccessibleTopology(pool),
-				VolumeContext:      buildVolumeContext(pool, sr),
+				VolumeContext:      buildVolumeContext(pool, sr, storageType),
 			},
 		}, nil
 	}
@@ -379,7 +430,7 @@ func (driver *xenorchestraCSIDriver) CreateVolume(ctx context.Context, req *csi.
 			VolumeId:           volumeID.String(),
 			CapacityBytes:      capacityBytes,
 			AccessibleTopology: driver.buildAccessibleTopology(pool),
-			VolumeContext:      buildVolumeContext(pool, sr),
+			VolumeContext:      buildVolumeContext(pool, sr, storageType),
 		},
 	}, nil
 }
@@ -508,12 +559,13 @@ func (driver *xenorchestraCSIDriver) buildAccessibleTopology(pool *payloads.Pool
 
 // buildVolumeContext constructs the CSI VolumeContext map that is stored in the PV's
 // volumeAttributes and passed back to ControllerPublishVolume / NodeStageVolume.
-func buildVolumeContext(pool *payloads.Pool, sr *payloads.StorageRepository) map[string]string {
+func buildVolumeContext(pool *payloads.Pool, sr *payloads.StorageRepository, storageType string) map[string]string {
 	return map[string]string{
-		VolumeContextKeySRID:     sr.ID.String(),
-		VolumeContextKeySRName:   sr.NameLabel,
-		VolumeContextKeyPoolID:   pool.ID.String(),
-		VolumeContextKeyPoolName: pool.NameLabel,
+		VolumeContextKeySRID:        sr.ID.String(),
+		VolumeContextKeySRName:      sr.NameLabel,
+		VolumeContextKeyPoolID:      pool.ID.String(),
+		VolumeContextKeyPoolName:    pool.NameLabel,
+		VolumeContextKeyStorageType: storageType,
 	}
 }
 

--- a/pkg/xenorchestra-csi/controllerserver.go
+++ b/pkg/xenorchestra-csi/controllerserver.go
@@ -313,8 +313,7 @@ func (driver *xenorchestraCSIDriver) CreateVolume(ctx context.Context, req *csi.
 		}
 	}
 
-	diskName := driver.vdiNamePrefix + volumeName
-	klog.V(5).InfoS("Creating volume", "diskName", diskName, "capacityBytes", capacityBytes)
+	klog.V(5).InfoS("Creating volume", "namePrefix", driver.vdiNamePrefix, "volumeName", volumeName, "capacityBytes", capacityBytes)
 
 	// Resolve which pool to provision into.
 	//
@@ -418,12 +417,12 @@ func (driver *xenorchestraCSIDriver) CreateVolume(ctx context.Context, req *csi.
 		}, nil
 	}
 
-	vdiID, volumeID, err := driver.xoClient.CreateNewVolume(ctx, sr.ID, diskName, capacityBytes, volumeName, DriverName, driver.clusterTag)
+	vdiID, volumeID, err := driver.xoClient.CreateNewVolume(ctx, sr.ID, driver.vdiNamePrefix, capacityBytes, volumeName, DriverName, driver.clusterTag)
 	if err != nil {
-		klog.ErrorS(err, "Failed to create VDI", "diskName", diskName, "capacityBytes", capacityBytes)
+		klog.ErrorS(err, "Failed to create VDI", "volumeName", volumeName, "capacityBytes", capacityBytes)
 		return nil, status.Errorf(codes.Internal, "Failed to create VDI: %v", err)
 	}
-	klog.V(5).InfoS("VDI created", "vdiID", vdiID, "volumeID", volumeID, "diskName", diskName)
+	klog.V(5).InfoS("VDI created", "vdiID", vdiID, "volumeID", volumeID, "volumeName", volumeName)
 
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{

--- a/pkg/xenorchestra-csi/driveroptions.go
+++ b/pkg/xenorchestra-csi/driveroptions.go
@@ -45,8 +45,8 @@ type DriverOptions struct {
 	ConfigFile string
 	// NodeMetadataSource selects how the node plugin resolves pool ID and VM identity.
 	NodeMetadataSource NodeMetadataSource
-	// VDINamePrefix is prepended to the Kubernetes volume name when constructing
-	// the VDI name label in Xen Orchestra. Defaults to DefaultVDINamePrefix ("csi-").
+	// VDINamePrefix is prepended to the VDI name label in Xen Orchestra.
+	// See xenorchestracsi.BuildVDINameLabel for the full format.
 	VDINamePrefix string
 	// ClusterTag is added to every VDI created by this driver and used to filter
 	// VDIs. Use a unique value per cluster when running multiple clusters against the same

--- a/test/sanity/fakedriver_test.go
+++ b/test/sanity/fakedriver_test.go
@@ -45,7 +45,7 @@ func NewFakeDriver(t *testing.T, options *xenorchestracsi.DriverOptions, fakeMou
 	mockXoClient.EXPECT().SR().Return(mockSR).AnyTimes()
 
 	mockXoClient.EXPECT().CreateNewVolume(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, srID uuid.UUID, diskName string, capacityBytes int64, volumeName string, _ string, _ string) (uuid.UUID, uuid.UUID, error) {
+		func(_ context.Context, srID uuid.UUID, namePrefix string, capacityBytes int64, volumeName string, _ string, _ string) (uuid.UUID, uuid.UUID, error) {
 			vdiID := uuid.Must(uuid.NewV4())
 			volumeId := uuid.Must(uuid.NewV4())
 			vdiStore.Lock()
@@ -53,7 +53,7 @@ func NewFakeDriver(t *testing.T, options *xenorchestracsi.DriverOptions, fakeMou
 			vdiStore.byID[vdiID] = payloads.VDI{
 				ID:        vdiID,
 				SR:        srID,
-				NameLabel: diskName,
+				NameLabel: clients.BuildVDINameLabel(namePrefix, volumeId.String(), volumeName),
 				Size:      capacityBytes,
 				OtherConfig: map[string]string{
 					clients.VDIOtherConfigKeyPVName:   volumeName,


### PR DESCRIPTION
## Summary

Add `storageType: local` StorageClass parameter to pin VDIs to host-local SRs with automatic migration on attach/reschedule.

- **XoClient**: `FindLocalSRForHost`, `FindLocalSRsForPool`, `MigrateVDIAndWait` — discover local SRs and migrate VDIs with blocking task.
- **ControllerServer**: orchestrate two-phase local storage provisioning (create on arbitrary local SR in `CreateVolume`, migrate to target host's local SR in `ControllerPublishVolume`).
- **Tests**: unit tests with mocked XoClient for local SR discovery and VDI migration.
- **Docs**: new `docs/references/local-storage.md` reference; updated install guide, topology docs, and README with feature matrix.

---

## VDI name_label fallback for resilient volume lookup

Embed the CSI `volumeId` in the VDI `name_label` (`<prefix><volumeId>-<volumeName>`) so `GetVDIByVolumeId` can fall back to a `name_label` search when `other_config` has been erased (e.g. after a VDI migration across SRs).

- **`GetVDIByVolumeId`**: primary lookup via `other_config:kubernetes_volume_id`; fallback via `name_label:<volumeId>` with ambiguous-match handling. All callers (`DeleteVolume`, `ControllerPublishVolume`, `ControllerUnpublishVolume`) benefit automatically — no signature change.
- **`CreateNewVolume`**: `diskName` param replaced with `namePrefix`; `name_label` and `name_description` built internally via helpers in the `clients` package.
- **`clients/helpers.go`**: `BuildVDINameLabel` and `BuildVDINameDescription` extracted here to keep the parent package import-cycle-free.
- **Tests**: unit tests for both builder functions and all `GetVDIByVolumeId` branches (primary hit, fallback hit, not found, ambiguous via both paths, API errors).
- **Docs**: new `docs/references/vdi-lookup-and-identification.md` reference; optional `v0.3.0→v0.4.0` migration guide (single-volume `xe` rename steps); `README.md` limitations section and version-migrations section.

## How local storage works

1. **Provision** (`CreateVolume`): driver picks a local SR from the pool via `FindLocalSRsForPool` and creates the VDI there.
2. **Attach** (`ControllerPublishVolume`): driver resolves target host → `FindLocalSRForHost` → if VDI is on a different SR, calls `MigrateVDIAndWait` to migrate before attaching.
3. Migration changes the VDI UUID; the driver re-locates the VDI via `other_config:kubernetes_volume_id`, with `name_label` as a fallback if `other_config` was erased during migration.

## Requirements

- `volumeBindingMode: WaitForFirstConsumer` on the StorageClass
- Each host must have at least one local user-data SR (plugged, not in maintenance mode)

## Limitations

- CSI-managed VDIs **must not be renamed** in Xen Orchestra — the `name_label` fallback depends on the name set at creation time. See [VDI Lookup and Identification](docs/references/vdi-lookup-and-identification.md).

## Changes

| Area | Change |
| ---- | ------ |
| `pkg/xenorchestra-csi/clients/xoclient.go` | `FindLocalSRForHost`, `FindLocalSRsForPool`, `MigrateVDIAndWait`; `CreateNewVolume` uses `namePrefix`; `GetVDIByVolumeId` with `name_label` fallback |
| `pkg/xenorchestra-csi/clients/helpers.go` | New: `BuildVDINameLabel`, `BuildVDINameDescription` |
| `pkg/xenorchestra-csi/clients/xoclient_test.go` | Unit tests for local SR discovery, VDI migration, builder helpers, and `GetVDIByVolumeId` all branches |
| `pkg/xenorchestra-csi/clients/mock/xoclient.go` | Regenerated mock |
| `pkg/xenorchestra-csi/controllerserver.go` | `storageType: local` handling; passes `namePrefix` to `CreateNewVolume` |
| `pkg/xenorchestra-csi/constants.go` | `StorageTypeLocal`; helpers moved to `clients` package |
| `pkg/xenorchestra-csi/driveroptions.go` | Updated `VDINamePrefix` comment |
| `test/sanity/fakedriver_test.go` | Updated fake `CreateNewVolume` closure |
| `docs/references/local-storage.md` | New: SR selection, migration, idempotency, live-migration behavior |
| `docs/references/vdi-lookup-and-identification.md` | New: lookup strategy, `other_config` erasure scenarios, limitations |
| `docs/migrations/v0.3.0-to-v0.4.0.md` | New: optional `name_label` backfill guide (single-volume steps only) |
| `docs/install.md` | Local SR installation section |
| `docs/topology.md` | Updated local SR section |
| `docs/README.md` | Updated index with new references and migration |
| `README.md` | Limitations section (do not rename VDIs), version-migrations section |
| `examples/csi-app-local-storage.yaml` | Example StorageClass + PVC + Pod |
