### PR TITLE
refactor: replace other_config with tags for VDI lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ you cannot run the CCM (see [Topology and Placement](docs/topology.md)).
 - [Topology and Placement](docs/topology.md) – pool boundary, live migration behaviour, CCM dependency.
 - [Developer guide](docs/development.md) – build, `kxo` helper, DevSpace, MicroK8s registry, remote debugging.
 - [Reference: Volume Handle and Volume ID in v0.3.0](docs/references/volume-handle-and-volume-id-v0.3.0.md) – details about stable CSI identity semantics.
-- [Reference: VDI Lookup and Identification](docs/references/vdi-lookup-and-identification.md) – how VDIs are located, `other_config` erasure, fallback behaviour, and limitations.
+- [Reference: VDI Lookup and Identification](docs/references/vdi-lookup-and-identification.md) – how VDIs are located, tag-based lookup, fallback behaviour, and limitations.
 - [Reference: Local Storage: VDI Placement and Migration](docs/references/local-storage.md) – SR selection, VDI migration, idempotency, and VM live-migration behaviour.
 
 ## Version migrations
@@ -48,25 +48,25 @@ changes to existing VDIs. Each guide is self-contained and includes rollback
 instructions.
 
 - [v0.2.0 to v0.3.0](docs/migrations/v0.2.0-to-v0.3.0.md) – **required** — backfill `other-config:kubernetes_volume_id` on legacy VDIs.
-- [v0.3.0 to v0.4.0](docs/migrations/v0.3.0-to-v0.4.0.md) – **optional** — backfill `name_label` with volume ID for pre-v0.4.0 VDIs (recommended before any VDI migration).
+- [v0.3.0 to v0.4.0](docs/migrations/v0.3.0-to-v0.4.0.md) – **required** — migrate VDI metadata from `other_config` to tags (mandatory for existing v0.3.0 dynamic volumes).
 
 ## Limitations
 
 ### Do not rename CSI-managed VDIs in Xen Orchestra
 
 The driver uses the VDI `name_label` as a fallback lookup when the
-`other_config:kubernetes_volume_id` key is missing (e.g. after a VDI
-migration). The `name_label` is set at creation time
+`k8s:volumeId:<volumeId>` tag is missing (e.g. after tag erasure). The
+`name_label` is set at creation time
 to `<prefix><volumeId>-<volumeName>`.
 
-**Renaming a VDI in Xen Orchestra breaks this fallback.** If `other_config`
+**Renaming a VDI in Xen Orchestra breaks this fallback.** If the tag
 has also been erased, the driver will no longer be able to locate the VDI and
 volume operations (`DeleteVolume`, `ControllerUnpublishVolume`) will fail  and
 the VDI will be considered deleted.
 
 CSI-managed VDIs are identifiable by:
+- the `k8s:volumeId:<volumeId>` tag,
 - the `csi-` prefix in their `name_label` (or the prefix set with the flag `--vdi-name-prefix`),
-- the `kubernetes_created_by` key in their `other_config`,
 - the `name_description` field set to `VDI managed by the Kubernetes CSI; pv-name=<pv-name>`.
 
 See [VDI Lookup and Identification](docs/references/vdi-lookup-and-identification.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ This folder is organized by purpose:
 ## Migrations
 
 - [v0.2.0 to v0.3.0](migrations/v0.2.0-to-v0.3.0.md)
-- [v0.3.0 to v0.4.0](migrations/v0.3.0-to-v0.4.0.md) *(optional — backfill `name_label` with volume ID for pre-v0.4.0 VDIs)*
+- [v0.3.0 to v0.4.0](migrations/v0.3.0-to-v0.4.0.md) *(required for existing v0.3.0 dynamic volumes — migrate metadata from `other_config` to tags)*
 
 ## References
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -277,7 +277,9 @@ selection, VDI migration, idempotency, and VM live-migration behaviour.
 
 #### Static provisioning (pre-existing VDI)
 
-No `poolId` is required. The volume is identified by its VDI UUID in the PV manifest.
+No `poolId` is required. The volume is identified by its raw VDI UUID in the PV manifest.
+This remains supported in v0.4.0: static volumes use `volumeHandle = <VDI UUID>` and
+are resolved through a direct VDI UUID fallback when tag-based lookup does not apply.
 
 ```bash
 kubectl apply -f examples/csi-storageclass.yaml
@@ -348,7 +350,7 @@ kubectl apply -f examples/csi-app.yaml
 ## Static volume provisioning
 
 Use a VDI that already exists in XenOrchestra.
-No `poolId` is required; the volume is bound by its VDI UUID.
+No `poolId` is required; the volume is bound by its raw VDI UUID.
 
 ### 1. Create a VDI in Xen Orchestra
 
@@ -435,7 +437,7 @@ csi.xenorchestra.vates.tech
 
 | Field | Description | Required | Example |
 | ----- | ----------- | -------- | ------- |
-| `volumeHandle` | UUID of the existing VDI | Yes | `b05f63f2-692a-4833-9453-980a73f9f27f` |
+| `volumeHandle` | Raw UUID of the existing VDI | Yes | `b05f63f2-692a-4833-9453-980a73f9f27f` |
 | `driver` | Must be `csi.xenorchestra.vates.tech` | Yes | — |
 
 ### Dynamic provisioning – StorageClass parameters

--- a/docs/migrations/batch-migrate-v0.3.0-to-v0.4.0.sh
+++ b/docs/migrations/batch-migrate-v0.3.0-to-v0.4.0.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PREFIX="${PREFIX:-csi-}"
+DRY_RUN="${DRY_RUN:-true}"
+
+migrated=0
+skipped=0
+errors=0
+
+# Extract a key-value from other-config line (semicolon-separated).
+# Usage: xe_get_other_config "output" "kubernetes_pv_name"
+xe_get_other_config() {
+    local output="$1"
+    local key="$2"
+    local line
+    line=$(echo "$output" | { grep -E "^\s+other-config" || true; } | head -1)
+    [[ -z "$line" ]] && return 0
+    echo "$line" | tr ';' '\n' | { grep -E "^\s*${key}:" || true; } | head -1 | sed "s/^[[:space:]]*${key}:[[:space:]]*//"
+}
+
+# Extract a top-level param value (e.g. name-label, uuid).
+xe_get_param() {
+    local output="$1"
+    local param="$2"
+    echo "$output" | { grep -E "^${param} \(" || true; } | head -1 | sed "s/^${param} ([^(]*):[[:space:]]*//"
+}
+
+echo "=== v0.3.0 → v0.4.0 batch migration ==="
+echo "PREFIX : ${PREFIX}"
+echo "DRY_RUN: ${DRY_RUN}"
+echo ""
+
+# xe vdi-list --minimal returns comma-separated UUIDs
+VDI_LIST=$(xe vdi-list --minimal)
+IFS=',' read -ra VDI_ARRAY <<< "$VDI_LIST"
+
+echo "Processing ${#VDI_ARRAY[@]} VDIs..."
+
+for VDI_UUID in "${VDI_ARRAY[@]}"; do
+    VDI_UUID=$(echo "$VDI_UUID" | tr -d '[:space:]')
+    [[ -z "$VDI_UUID" ]] && continue
+
+    # echo "Processing VDI ${VDI_UUID}..."
+    PARAM_OUTPUT=$(xe vdi-param-list uuid="$VDI_UUID" 2>/dev/null || true)
+
+    if [[ -z "$PARAM_OUTPUT" ]]; then
+        continue
+    fi
+
+    PV_NAME=$(xe_get_other_config "$PARAM_OUTPUT" "kubernetes_pv_name")
+
+    if [[ -z "$PV_NAME" ]]; then
+        continue
+    fi
+
+    VOLUME_HANDLE=$(xe_get_other_config "$PARAM_OUTPUT" "kubernetes_volume_id")
+    CURRENT_NAME=$(xe_get_param "$PARAM_OUTPUT" "name-label")
+
+    if [[ -z "$VOLUME_HANDLE" ]]; then
+        echo "[SKIPPED] VDI ${VDI_UUID}: missing kubernetes_volume_id"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    NEW_NAME_LABEL="${PREFIX}${VOLUME_HANDLE}-${PV_NAME}"
+    VOLUME_HANDLE_TAG="k8s:volumeId:${VOLUME_HANDLE}"
+    PV_NAME_TAG="k8s:pvName:${PV_NAME}"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        actions=()
+        if [[ "$CURRENT_NAME" != "$NEW_NAME_LABEL" ]]; then
+            actions+=("rename '${CURRENT_NAME}' → '${NEW_NAME_LABEL}'")
+        fi
+        actions+=("add tag '${VOLUME_HANDLE_TAG}'")
+        actions+=("add tag '${PV_NAME_TAG}'")
+        echo "[DRY-RUN] VDI ${VDI_UUID}: $(IFS='; '; echo "${actions[*]}")"
+        migrated=$((migrated + 1))
+        continue
+    fi
+
+    action_count=0
+
+    if [[ "$CURRENT_NAME" != "$NEW_NAME_LABEL" ]]; then
+        if ! xe vdi-param-set uuid="$VDI_UUID" name-label="$NEW_NAME_LABEL" 2>/dev/null; then
+            echo "[ERROR] VDI ${VDI_UUID}: failed to set name-label"
+            errors=$((errors + 1))
+            continue
+        fi
+        action_count=$((action_count + 1))
+    fi
+
+    if ! xe vdi-param-add uuid="$VDI_UUID" param-name=tags param-key="$VOLUME_HANDLE_TAG" 2>/dev/null; then
+        echo "[ERROR] VDI ${VDI_UUID}: failed to add tag '${VOLUME_HANDLE_TAG}'"
+        errors=$((errors + 1))
+        continue
+    fi
+    action_count=$((action_count + 1))
+
+    if ! xe vdi-param-add uuid="$VDI_UUID" param-name=tags param-key="$PV_NAME_TAG" 2>/dev/null; then
+        echo "[ERROR] VDI ${VDI_UUID}: failed to add tag '${PV_NAME_TAG}'"
+        errors=$((errors + 1))
+        continue
+    fi
+    action_count=$((action_count + 1))
+
+    echo "[MIGRATED] VDI ${VDI_UUID} (${action_count} change(s))"
+    migrated=$((migrated + 1))
+done
+
+echo ""
+echo "=== Summary ==="
+echo "migrated: ${migrated}"
+echo "skipped : ${skipped}"
+echo "errors  : ${errors}"

--- a/docs/migrations/v0.3.0-to-v0.4.0.md
+++ b/docs/migrations/v0.3.0-to-v0.4.0.md
@@ -2,129 +2,235 @@
 
 ## Summary
 
-v0.4.0 changes the VDI `name_label` format to embed the CSI volume ID:
+**This migration is mandatory** for existing v0.3.0 dynamic volumes.
 
-- **v0.3.0 format**: `<prefix><volumeName>` (e.g. `csi-pvc-my-app-data`)
-- **v0.4.0 format**: `<prefix><volumeId>-<volumeName>` (e.g. `csi-12345678-90ab-cdef-pvc-my-app-data`)
+v0.4.0 changes how the driver stores and looks up VDI metadata:
 
-This change enables a `name_label`-based fallback lookup when
-`other_config:kubernetes_volume_id` has been erased (e.g. after a VDI
-migration across SRs or a manual admin operation). See
-[VDI Lookup and Identification](../references/vdi-lookup-and-identification.md)
-for background.
+- **v0.3.0**: CSI identity stored in `VDI.other_config`
+- **v0.4.0**: CSI identity stored in `VDI.tags` with format `k8s:<key>:<value>`
 
-**This migration is optional.** Volumes created before v0.4.0 continue to
-work normally as long as `other_config:kubernetes_volume_id` is intact. The
-migration only becomes necessary if you want the fallback to work for legacy
-volumes — for example, before performing a VDI migration or SR consolidation
-that may erase `other_config`.
+Without this migration, existing v0.3.0 dynamic volumes will not be discoverable
+by the v0.4.0 driver and volume operations (`DeleteVolume`, `ControllerPublishVolume`,
+`ControllerUnpublishVolume`, `ValidateVolumeCapabilities`) will fail.
+
+### Prerequisite: pre-v0.3.0 volumes
+
+If you have volumes created before v0.3.0, you **must first apply the
+[v0.2.0 to v0.3.0 migration](v0.2.0-to-v0.3.0.md)** before proceeding with
+this guide. This guide only covers the migration from v0.3.0 to v0.4.0.
+
+### Static volumes
+
+Static volumes (pre-existing VDIs with `volumeHandle` set to the raw VDI UUID)
+are **not affected** by this migration. The v0.4.0 driver includes a fallback
+lookup path that resolves static volumes by their raw VDI UUID. You may still
+apply this migration to static volumes voluntarily to benefit from the new
+metadata model, but it is not required.
 
 ---
 
-## Why apply this migration
+## What changes
 
-After upgrading to v0.4.0 newly provisioned volumes automatically include the
-CSI volume ID in their `name_label` and benefit from the fallback.
+Each v0.3.0 dynamic VDI must be updated with:
 
-Volumes provisioned under v0.3.0 keep their old `name_label` and do **not**
-benefit from the fallback. If their `other_config` is subsequently erased (by
-a VDI migration or admin operation), the driver will fail to
-locate them.
+1. **Tag `k8s:volumeId:<existing-volumeHandle>`** — the canonical CSI identity.
+   For the v0.3.0 dynamic volumes covered by this guide, the value comes from
+   `other_config.kubernetes_volume_id`.
 
-Applying the migration re-labels legacy VDIs to the new format so that the
-fallback is available for them too.
+2. **Tag `k8s:pvName:<kubernetes_pv_name>`** — the Kubernetes PV name, taken
+   from `other_config.kubernetes_pv_name`.
+
+3. **Renamed `name_label`** — from `<prefix><volumeName>` to
+   `<prefix><volumeHandle>-<volumeName>`, so the fallback lookup path works.
+
+The legacy `other_config` keys are **not removed**. They remain as compatibility
+data for rollback and manual recovery.
 
 ---
 
 ## Prerequisites
 
-- Access to an XCP-ng host with `xe` CLI privileges.
-- The list of VDI UUIDs used by existing Kubernetes PersistentVolumes.
-- The CSI volume ID (`kubernetes_volume_id`) must be present in `other_config`
-  for each VDI — if it is missing, apply the
-  [v0.2.0 to v0.3.0 migration](v0.2.0-to-v0.3.0.md) first.
-- A maintenance window is recommended. The rename is instant and non-destructive
+- Access to Xen Orchestra REST API from your admin workstation.
+- `kubectl` configured with access to the target Kubernetes cluster from your admin workstation.
+- A Xen Orchestra authentication token exported as `XO_TOKEN`.
+- A maintenance window is recommended. The changes are instant and non-destructive
   but it is good practice to avoid concurrent volume operations.
 
----
-
-## Single-volume migration
-
-### 1. Retrieve the current metadata
-
-```bash
-xe vdi-param-get uuid=<VDI_UUID> param-name=name-label
-xe vdi-param-get uuid=<VDI_UUID> param-name=other-config
-```
-
-Note the current `name_label` value (e.g. `csi-pvc-my-app-data`) and the
-value of `kubernetes_volume_id` in `other-config` (e.g.
-`12345678-90ab-cdef-1234-567890abcdef`).
-
-Also note the `kubernetes_pv_name` value — this is the `<volumeName>` part
-of the new label.
-
-### 2. Build the new name_label
-
-The new format is: `<currentPrefix><volumeId>-<volumeName>`
-
-Where:
-- `<currentPrefix>` is the `csi-` prefix (or the custom prefix configured
-  via `--vdi-name-prefix` on the driver).
-- `<volumeId>` is the value of `other_config:kubernetes_volume_id`.
-- `<volumeName>` is the value of `other_config:kubernetes_pv_name`.
-
-Example:
-- Current `name_label`: `csi-pvc-my-app-data`
-- `kubernetes_volume_id`: `12345678-90ab-cdef-1234-567890abcdef`
-- `kubernetes_pv_name`: `pvc-my-app-data`
-- New `name_label`: `csi-12345678-90ab-cdef-1234-567890abcdef-pvc-my-app-data`
-
-### 3. Apply the rename
-
-```bash
-xe vdi-param-set uuid=<VDI_UUID> name-label=<NEW_NAME_LABEL>
-```
-
 Example:
 
 ```bash
-xe vdi-param-set uuid=3ceb6f8c-4226-4133-92f6-52ec7be8cc4d \
-  name-label="csi-12345678-90ab-cdef-1234-567890abcdef-pvc-my-app-data"
+export XO_URL="http://10.30.135.2:9000"
+export XO_TOKEN="<your-xo-authentication-token>"
 ```
 
-### 4. Verify
+
+## Step-by-step migration
+
+### 1. Identify the volumes to migrate
+
+List the Kubernetes PVs and note the PV name you want to migrate:
 
 ```bash
-xe vdi-param-get uuid=<VDI_UUID> param-name=name-label
+kubectl get pv -o custom-columns=PV:.metadata.name,VOLUME_HANDLE:.spec.csi.volumeHandle,STATUS:.status.phase
 ```
 
-Expected output:
+For each PV in scope, note:
+- `<PV_NAME>` — the Kubernetes PV name
+- `<VOLUME_HANDLE> — the unique CSI volume ID (UUID)
 
+This step-by-step guide is only for existing **v0.3.0 dynamic** volumes.
+**Static volumes are excluded from this step-by-step migration guide.**
+
+### 2. Locate the backing VDI in Xen Orchestra
+
+For the `v0.3.0` dynamic volumes covered by this guide, the legacy metadata is
+still stored in `VDI.other_config`.
+
+You can retrieve it directly from Xen Orchestra with:
+
+```bash
+# Run on your admin workstation
+curl -s -X GET \
+  -H "Cookie: authenticationToken=$XO_TOKEN" \
+  "$XO_URL/rest/v0/vdis?fields=name_label,id,other_config&filter=other_config:kubernetes_pv_name?"
 ```
-csi-12345678-90ab-cdef-1234-567890abcdef-pvc-my-app-data
+
+From the returned JSON, identify the VDI whose:
+
+- `other_config.kubernetes_pv_name` matches your Kubernetes PV name
+
+Or from the `xe` CLI on a XCP-ng host:
+
+```bash
+xe vdi-list other-config:kubernetes_pv_name=$PV_NAME params=uuid,name-label,other-config,tags
 ```
+
+For that VDI, note:
+
+- `<VDI_UUID>` from `uuid`
+- `<PV_NAME>` from `other_config.kubernetes_pv_name`
+- `<VOLUME_HANDLE>` from `other_config.kubernetes_volume_id`
+
+
+### 3. Generate the migration commands
+
+Note: following commands must be run on a XCP-ng host of the pool.
+
+Set the variables for the VDI you selected:
+
+```bash
+PV_NAME="<pv-name>"
+VDI_UUID="<xo-vdi-uuid>"
+VOLUME_HANDLE="<other_config.kubernetes_volume_id>"
+PREFIX="csi-"  # or your custom --vdi-name-prefix
+NEW_NAME_LABEL="${PREFIX}${VOLUME_HANDLE}-${PV_NAME}"
+```
+
+For this `v0.3.0 -> v0.4.0` migration, the canonical values to migrate are:
+
+- `k8s:volumeId:<VOLUME_HANDLE>`
+- `k8s:pvName:<PV_NAME>`
+
+Set new variables for the VDI:
+
+```bash
+VOLUME_HANDLE_TAG="k8s:volumeId:${VOLUME_HANDLE}"
+PV_NAME_TAG="k8s:pvName:${PV_NAME}"
+```
+
+Preview the exact `xe` request that will be executed to update the `name_label`:
+
+```bash
+printf 'xe vdi-param-set uuid=%q name-label=%q\n' \
+  "$VDI_UUID" \
+  "$NEW_NAME_LABEL"
+```
+
+And the `xe` request to set the new tags:
+
+```bash
+printf 'xe vdi-param-add uuid=%q param-name=tags param-key=%q\n' \
+  "$VDI_UUID" \
+  "$VOLUME_HANDLE_TAG"
+
+printf 'xe vdi-param-add uuid=%q param-name=tags param-key=%q\n' \
+  "$VDI_UUID" \
+  "$PV_NAME_TAG"
+```
+### 4. Execute the migration
+
+Update the VDI `name_label` and add the new tags:
+
+```bash
+xe vdi-param-set uuid="$VDI_UUID" name-label="$NEW_NAME_LABEL"
+
+xe vdi-param-add uuid="$VDI_UUID" param-name=tags param-key="$VOLUME_HANDLE_TAG"
+xe vdi-param-add uuid="$VDI_UUID" param-name=tags param-key="$PV_NAME_TAG"
+```
+
+### 5. Verify
+
+Check the VDI again:
+
+```bash
+xe vdi-list uuid="$VDI_UUID" params=uuid,name-label,other-config,tags
+```
+
+Expected result:
+- `tags` contains `k8s:volumeId:<VOLUME_HANDLE>`
+- `tags` contains `k8s:pvName:<PV_NAME>`
+- `name_label` is `<prefix><VOLUME_HANDLE>-<PV_NAME>`
+- `other_config` is unchanged
 
 ---
 
 ## Rollback
 
-The rename is non-destructive. To restore the original `name_label`:
+To rollback, remove the new tags.
+
+The legacy `other_config` keys are preserved and do not need to be restored.
 
 ```bash
-xe vdi-param-set uuid=<VDI_UUID> name-label=<ORIGINAL_NAME_LABEL>
+xe vdi-param-remove uuid="$VDI_UUID" param-name=tags param-key="$VOLUME_HANDLE_TAG"
+xe vdi-param-remove uuid="$VDI_UUID" param-name=tags param-key="$PV_NAME_TAG"
 ```
-
-No other metadata is modified by this migration.
 
 ---
 
 ## Post-migration checks
 
 - Confirm existing PVs can still be attached and mounted.
-- Verify the new `name_label` contains the volume ID:
-  ```bash
-  xe vdi-param-get uuid=<VDI_UUID> param-name=name-label
-  ```
+- Verify the `k8s:volumeId` tag matches `other_config.kubernetes_volume_id`.
 - Validate that new volumes provisioned after the upgrade already carry the
-  new format (no manual action needed for those).
+  new tags (no manual action needed for those).
+
+---
+
+## Batch migration script
+
+A ready-to-use script is provided at `batch-migrate-v0.3.0-to-v0.4.0.sh`.
+
+It iterates over all VDIs on the pool using `xe vdi-list --minimal`, extracts
+`other_config.kubernetes_pv_name` and `other_config.kubernetes_volume_id` from
+each VDI, and applies the migration (rename + tags). VDIs missing either key
+are skipped.
+
+The script uses `xe` CLI commands and must be run on a XCP-ng host of the pool.
+
+**Preview mode (default):**
+
+```bash
+bash batch-migrate-v0.3.0-to-v0.4.0.sh
+```
+
+**Execute for real:**
+
+```bash
+DRY_RUN=false bash batch-migrate-v0.3.0-to-v0.4.0.sh
+```
+
+**Custom prefix:**
+
+```bash
+PREFIX=my-csi- DRY_RUN=false bash batch-migrate-v0.3.0-to-v0.4.0.sh
+```

--- a/docs/references/vdi-lookup-and-identification.md
+++ b/docs/references/vdi-lookup-and-identification.md
@@ -4,24 +4,32 @@
 
 This reference describes how the driver identifies and locates VDIs during
 volume lifecycle operations (`DeleteVolume`, `ControllerPublishVolume`,
-`ControllerUnpublishVolume`), and documents the known limitations around
-`other_config` erasure.
+`ControllerUnpublishVolume`, `ValidateVolumeCapabilities`), and documents the
+known limitations around tag erasure and legacy metadata.
 
 ---
 
-## Primary lookup: `other_config`
+## Primary lookup: VDI tags
 
-The driver's stable CSI volume ID is stored at creation time in the VDI
-`other_config` map under the key `kubernetes_volume_id`.
+The driver's stable CSI volume ID is stored at creation time in a VDI tag
+with the format `k8s:volumeId:<uuid>`.
 
 Every lookup first queries XO with the filter:
 
 ```
-other_config:kubernetes_volume_id:<volumeId>
+tags:/^k8s:volumeId:<volumeId>$/
 ```
 
 This is the authoritative source of truth. Under normal operating conditions
 this lookup always succeeds.
+
+Additional tags set at creation time:
+
+| Tag | Value | Purpose |
+|-----|-------|---------|
+| `k8s:volumeId:<uuid>` | CSI volume ID (UUID) | Primary lookup key |
+| `k8s:pvName:<pv-name>` | Kubernetes PV name | Idempotency check in `CreateVolume` |
+| `k8s:managedBy:<driver>@<version>` | Driver identifier | Identifies CSI-managed VDIs |
 
 ---
 
@@ -36,28 +44,64 @@ The VDI `name_label` is set at creation time to:
 For example: `csi-12345678-90ab-cdef-pvc-my-app-data`
 
 Because the CSI `volumeId` UUID is embedded in the name, the driver can
-fall back to searching by `name_label` if `other_config` returns no results:
+fall back to searching by `name_label` if the tag lookup returns no results:
 
 ```
 name_label:<volumeId>
 ```
 
+When a VDI is found via this fallback, the driver automatically recovers the
+`k8s:volumeId` and `k8s:pvName` tags so that future lookups use the primary
+path.
+
 The fallback is transparent to callers — `DeleteVolume`,
-`ControllerPublishVolume`, and `ControllerUnpublishVolume` all benefit from it
-automatically.
+`ControllerPublishVolume`, `ControllerUnpublishVolume`, and
+`ValidateVolumeCapabilities` all benefit from it automatically.
 
 ---
 
-## When `other_config` can be erased
+## Static volume lookup: direct VDI UUID
 
-The `other_config` map is XenServer/XCP-ng metadata that may be lost in
-certain operational scenarios:
+Static provisioning uses the raw VDI UUID as the `volumeHandle`. If neither
+the tag lookup nor the `name_label` fallback find a match, and the `volumeHandle`
+is a valid UUID, the driver attempts a direct VDI lookup by UUID.
 
-- **VDI migration** — migrations do not carry `other_config` to the destination SR.
-- **Manual admin edits** — an operator clearing `other_config` via the XAPI shell.
+This is intentionally the **last** fallback because dynamic volume handles can
+also be UUID-shaped, and the driver must avoid returning the wrong VDI.
 
-When `other_config:kubernetes_volume_id` is gone the driver automatically
-retries using the `name_label` fallback described above.
+When a VDI is found via direct UUID lookup, the driver also recovers the
+`k8s:volumeId` tag so that future lookups use the primary path.
+
+---
+
+## When tags can be erased
+
+VDI tags may be lost in certain operational scenarios:
+
+- **VDI migration** — migrations do not carry `tags` to the destination SR.
+- **Manual admin edits** — an operator removing tags via the XAPI shell or even more easily with the Xen Orchestra web interface.
+
+When the `k8s:volumeId` tag is gone, the driver automatically retries using
+the `name_label` fallback described above.
+
+---
+
+## Legacy `other_config` metadata (v0.3.0 and earlier)
+
+v0.3.0 and earlier stored CSI identity in `VDI.other_config` under keys:
+
+- `kubernetes_volume_id`
+- `kubernetes_pv_name`
+- `kubernetes_created_by`
+
+**v0.4.0 no longer reads `other_config` for runtime lookups.** These keys
+remain on migrated VDIs as legacy compatibility data for rollback and manual
+recovery, but they are not used by the driver at runtime.
+
+If you are upgrading from v0.3.0, you must apply the
+[v0.3.0 to v0.4.0 migration](../migrations/v0.3.0-to-v0.4.0.md) to backfill
+the new tag-based metadata. Without it, legacy dynamic volumes will not be
+discoverable.
 
 ---
 
@@ -68,29 +112,30 @@ retries using the `name_label` fallback described above.
 The `name_label` fallback relies on the VDI name remaining unchanged from
 the value set at creation. **Renaming a VDI in Xen Orchestra will break the
 fallback** and cause volume operations to fail with `ErrVolumeNotFound` if
-`other_config` has also been erased.
+the `k8s:volumeId` tag has also been erased.
 
 > **Do not rename CSI-managed VDIs in Xen Orchestra.**
-> CSI-managed VDIs are identifiable by the `csi-` prefix in their name
-> and the `kubernetes_created_by` key in their `other_config`.
+> CSI-managed VDIs are identifiable by the `k8s:volumeId` tag, the `csi-`
+> prefix in their `name_label`, and the `name_description` field set to
+> `VDI managed by the Kubernetes CSI; pv-name=<pv-name>`.
 
-### Both `other_config` and `name_label` are lost
+### Both tags and name_label are lost
 
-If both `other_config` and `name_label` are modified or lost, the driver
-can no longer locate the VDI automatically. Manual recovery is required:
+If both the `k8s:volumeId` tag and the `name_label` are modified or lost,
+the driver can no longer locate the VDI automatically. Manual recovery is
+required:
 
 1. Identify the VDI in XO by its size, SR, and the `name_description`
    field (set to `VDI managed by the Kubernetes CSI; pv-name=<pv-name>`).
-2. Restore the `other_config:kubernetes_volume_id` key to the CSI
-   volume ID stored in the PersistentVolume's `.spec.volumeHandle`.
-3. Or restore the `name_label` to `<vdiNamePrefix><volumeId>-<volumeName>`.
+2. Restore the `k8s:volumeId:<volumeHandle>` tag using the CSI volume ID
+   stored in the PersistentVolume's `.spec.csi.volumeHandle`.
+3. Or restore the `name_label` to `<vdiNamePrefix><volumeHandle>-<pvName>`.
 
 ### `DeleteVolume` with no fallback available
 
-If neither `other_config` nor `name_label` allow the VDI to be located,
-`DeleteVolume` returns the volume as deleted. Although the PV is deleted
-from Kubernetes, the VDI remains in Xen Orchestra.
-
+If neither tags, `name_label`, nor direct UUID lookup allow the VDI to be
+located, `DeleteVolume` returns the volume as deleted. Although the PV is
+deleted from Kubernetes, the VDI remains in Xen Orchestra.
 
 ---
 
@@ -98,11 +143,14 @@ from Kubernetes, the VDI remains in Xen Orchestra.
 
 | Field | Value | Purpose |
 |-------|-------|---------|
-| `name_label` | `<prefix><volumeId>-<volumeName>` | Human-readable name; used as fallback lookup key |
+| `tags: k8s:volumeId:<uuid>` | CSI volume ID (UUID) | Primary lookup key |
+| `tags: k8s:pvName:<pv-name>` | Kubernetes PV name | Idempotency in `CreateVolume` |
+| `tags: k8s:managedBy:<driver>@<version>` | Driver identifier | Identifies CSI-managed VDIs |
+| `name_label` | `<prefix><volumeId>-<volumeName>` | Human-readable name; fallback lookup key |
 | `name_description` | `VDI managed by the Kubernetes CSI; pv-name=<pv-name>` | Human-readable only; not used for lookups |
-| `other_config:kubernetes_volume_id` | CSI volume ID (UUID) | Primary lookup key |
-| `other_config:kubernetes_pv_name` | Kubernetes PV name | Informational |
-| `other_config:kubernetes_created_by` | Driver name | Identifies CSI-managed VDIs |
+| `other_config:kubernetes_volume_id` | CSI volume ID (UUID) | **Legacy** — v0.3.0 and earlier only |
+| `other_config:kubernetes_pv_name` | Kubernetes PV name | **Legacy** — v0.3.0 and earlier only |
+| `other_config:kubernetes_created_by` | Driver name | **Legacy** — v0.3.0 and earlier only |
 
 ---
 

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -63,8 +63,9 @@ in `AccessibleTopology`. This segment was removed for the following reasons:
   affinity is meaningful. The driver handles this via the `storageType: local`
   StorageClass parameter: in `ControllerPublishVolume` the VDI is migrated to the
   target host's local SR before being attached to the VM. Because migration changes
-  the VDI UUID, the PVC UID stored in `VDI.other_config` is used to re-locate the
-  VDI after VM live-migration. See the
+  the VDI UUID, the stable CSI volume handle stored in the VDI tag
+  `k8s:volumeId:<volumeHandle>` is used to re-locate the VDI after VM live-migration.
+  See the
   [Local Storage reference](references/local-storage.md) for full details.
 
 ## Cross-pool migration restriction

--- a/pkg/xenorchestra-csi/clients/constants.go
+++ b/pkg/xenorchestra-csi/clients/constants.go
@@ -15,15 +15,20 @@ limitations under the License.
 */
 package clients
 
-// VDIOtherConfigKeyVolumeId is the XO VDI other_config key that stores the
+// tagPrefix is the common prefix for all VDI tags used by this driver.
+const tagPrefix = "k8s"
+
+// VDITagKeyVolumeId is the key segment used in the VDI tag that stores the
 // CSI volume ID (UUID) generated at CreateVolume time.
-// This UUID is stable across SR migrations (VDI UUID changes, volume ID does not).
-const VDIOtherConfigKeyVolumeId = "kubernetes_volume_id"
+// Full tag format: "k8s:volumeId:<uuid>"
+const VDITagKeyVolumeId = "volumeId"
 
-// VDIOtherConfigKeyCreatedBy is the key in VDI's other_config map that identifies
-// the component that created the VDI (always set to the driver name).
-const VDIOtherConfigKeyCreatedBy = "kubernetes_created_by"
+// VDITagKeyPVName is the key segment used in the VDI tag that stores the
+// Kubernetes PersistentVolume name associated with this VDI.
+// Full tag format: "k8s:pvName:<pv-name>"
+const VDITagKeyPVName = "pvName"
 
-// VDIOtherConfigKeyPVName is the key in VDI's other_config map that stores
-// the Kubernetes PersistentVolume name associated with this VDI.
-const VDIOtherConfigKeyPVName = "kubernetes_pv_name"
+// VDITagKeyManagedBy is the key segment used in the VDI tag that identifies
+// the driver that created and manages this VDI.
+// Full tag format: "k8s:managedBy:<driver-name>@<version>"
+const VDITagKeyManagedBy = "managedBy"

--- a/pkg/xenorchestra-csi/clients/errors.go
+++ b/pkg/xenorchestra-csi/clients/errors.go
@@ -15,7 +15,10 @@ limitations under the License.
 */
 package clients
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 // ErrVBDNotFound is returned when no VBD matches the given VDI and VM combination.
 var ErrVBDNotFound = errors.New("VBD not found")
@@ -28,3 +31,8 @@ var ErrVolumeIdAmbiguous = errors.New("multiple VDIs match volume ID")
 
 // ErrVolumeNameAmbiguous is returned when multiple VDIs match the same Kubernetes PV name.
 var ErrVolumeNameAmbiguous = errors.New("multiple VDIs match volume name")
+
+// IsNotFoundError reports whether err is an HTTP 404 from the Xen Orchestra REST
+func IsNotFoundError(err error) bool {
+	return strings.Contains(err.Error(), "API error: 404 Not Found")
+}

--- a/pkg/xenorchestra-csi/clients/helpers.go
+++ b/pkg/xenorchestra-csi/clients/helpers.go
@@ -15,12 +15,16 @@ limitations under the License.
 */
 package clients
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
 
 // BuildVDINameLabel constructs the VDI.name_label for a new volume.
 // The format is "<prefix><volumeId>-<volumeName>" (e.g. "csi-12345678-90ab-cdef-pvc-xyz").
 // The volumeId is embedded so that GetVDIByVolumeId can fall back to searching
-// by name_label when other_config has been erased.
+// by name_label when tags have been erased.
 func BuildVDINameLabel(prefix, volumeId, volumeName string) string {
 	return fmt.Sprintf("%s%s-%s", prefix, volumeId, volumeName)
 }
@@ -31,4 +35,30 @@ func BuildVDINameLabel(prefix, volumeId, volumeName string) string {
 // This field is not used for lookups.
 func BuildVDINameDescription(volumeName string) string {
 	return "VDI managed by the Kubernetes CSI; pv-name=" + volumeName
+}
+
+// BuildTag encodes a key-value pair as a VDI tag string using the format
+// "k8s:<key>:<value>".
+func BuildTag(key, value string) string {
+	return fmt.Sprintf("%s:%s:%s", tagPrefix, key, value)
+}
+
+// ParseTagValue returns the value associated with key from a tags slice.
+// It scans for a tag with the prefix "k8s:<key>:" and returns the remainder.
+// Returns an empty string if no matching tag is found.
+func ParseTagValue(tags []string, key string) string {
+	prefix := fmt.Sprintf("%s:%s:", tagPrefix, key)
+	for _, t := range tags {
+		if strings.HasPrefix(t, prefix) {
+			return t[len(prefix):]
+		}
+	}
+	return ""
+}
+
+// BuildTagFilter builds an XO REST API filter string that matches VDIs
+// whose tags contain exactly "k8s:<key>:<value>".
+// The value is regex-escaped for safety.
+func BuildTagFilter(key, value string) string {
+	return fmt.Sprintf("tags:/^%s$/", regexp.QuoteMeta(BuildTag(key, value)))
 }

--- a/pkg/xenorchestra-csi/clients/helpers.go
+++ b/pkg/xenorchestra-csi/clients/helpers.go
@@ -19,7 +19,18 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/vatesfr/xenorchestra-go-sdk/pkg/payloads"
 )
+
+const vdiNameDescriptionPVNameMarker = "pv-name="
+
+const (
+	dns1123LabelFmt     = `[a-z0-9](?:[-a-z0-9]*[a-z0-9])?`
+	dns1123SubdomainFmt = dns1123LabelFmt + `(?:\.` + dns1123LabelFmt + `)*`
+)
+
+var vdiNameDescriptionPVNameRe = regexp.MustCompile(`(?:^|;)\s*pv-name=(` + dns1123SubdomainFmt + `)(?:[\s;]|$)`)
 
 // BuildVDINameLabel constructs the VDI.name_label for a new volume.
 // The format is "<prefix><volumeId>-<volumeName>" (e.g. "csi-12345678-90ab-cdef-pvc-xyz").
@@ -34,7 +45,7 @@ func BuildVDINameLabel(prefix, volumeId, volumeName string) string {
 // can identify the backing Kubernetes PV in the Xen Orchestra UI.
 // This field is not used for lookups.
 func BuildVDINameDescription(volumeName string) string {
-	return "VDI managed by the Kubernetes CSI; pv-name=" + volumeName
+	return "VDI managed by the Kubernetes CSI; " + vdiNameDescriptionPVNameMarker + volumeName
 }
 
 // BuildTag encodes a key-value pair as a VDI tag string using the format
@@ -61,4 +72,41 @@ func ParseTagValue(tags []string, key string) string {
 // The value is regex-escaped for safety.
 func BuildTagFilter(key, value string) string {
 	return fmt.Sprintf("tags:/^%s$/", regexp.QuoteMeta(BuildTag(key, value)))
+}
+
+// recoverVolumeNameFromVDI tries to recover the Kubernetes PV name for a VDI.
+// It first reads the VDI name_description and falls back to parsing name_label.
+func recoverVolumeNameFromVDI(vdi *payloads.VDI, volumeId string) string {
+	if vdi == nil {
+		return ""
+	}
+
+	if volumeName := parseVolumeNameFromVDINameDescription(vdi.NameDescription); volumeName != "" {
+		return volumeName
+	}
+
+	return parseVolumeNameFromVDINameLabel(vdi.NameLabel, volumeId)
+}
+
+func parseVolumeNameFromVDINameDescription(nameDescription string) string {
+	matches := vdiNameDescriptionPVNameRe.FindStringSubmatch(nameDescription)
+	if len(matches) != 2 {
+		return ""
+	}
+
+	return matches[1]
+}
+
+func parseVolumeNameFromVDINameLabel(nameLabel, volumeId string) string {
+	if volumeId == "" {
+		return ""
+	}
+
+	nameLabelRe := regexp.MustCompile(fmt.Sprintf(`%s-(%s)$`, regexp.QuoteMeta(volumeId), dns1123SubdomainFmt))
+	matches := nameLabelRe.FindStringSubmatch(nameLabel)
+	if len(matches) != 2 {
+		return ""
+	}
+
+	return matches[1]
 }

--- a/pkg/xenorchestra-csi/clients/helpers_test.go
+++ b/pkg/xenorchestra-csi/clients/helpers_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright (c) 2025 Vates
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package clients
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// BuildTag
+// ---------------------------------------------------------------------------
+
+func TestBuildTag(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		want  string
+	}{
+		{
+			name:  "volume ID tag",
+			key:   VDITagKeyVolumeId,
+			value: "aaaaaaaa-0000-0000-0000-000000000001",
+			want:  "k8s:volumeId:aaaaaaaa-0000-0000-0000-000000000001",
+		},
+		{
+			name:  "PV name tag",
+			key:   VDITagKeyPVName,
+			value: "pvc-my-pv",
+			want:  "k8s:pvName:pvc-my-pv",
+		},
+		{
+			name:  "managed-by tag",
+			key:   VDITagKeyManagedBy,
+			value: "csi.xenorchestra.vates.tech@0.4.0",
+			want:  "k8s:managedBy:csi.xenorchestra.vates.tech@0.4.0",
+		},
+		{
+			name:  "value with colons is preserved verbatim",
+			key:   "someKey",
+			value: "a:b:c",
+			want:  "k8s:someKey:a:b:c",
+		},
+		{
+			name:  "empty value",
+			key:   VDITagKeyVolumeId,
+			value: "",
+			want:  "k8s:volumeId:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildTag(tt.key, tt.value)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseTagValue
+// ---------------------------------------------------------------------------
+
+func TestParseTagValue(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []string
+		key  string
+		want string
+	}{
+		{
+			name: "matching tag first",
+			tags: []string{"k8s:volumeId:abc-123"},
+			key:  VDITagKeyVolumeId,
+			want: "abc-123",
+		},
+		{
+			name: "matching tag among several",
+			tags: []string{
+				"k8s:pvName:pvc-x",
+				"k8s:volumeId:abc-456",
+				"k8s:managedBy:csi@0.4.0",
+				"some-other-tag",
+			},
+			key:  VDITagKeyVolumeId,
+			want: "abc-456",
+		},
+		{
+			name: "key not present returns empty string",
+			tags: []string{"k8s:pvName:pvc-x", "k8s:managedBy:csi@0.4.0"},
+			key:  VDITagKeyVolumeId,
+			want: "",
+		},
+		{
+			name: "nil tags returns empty string",
+			tags: nil,
+			key:  VDITagKeyVolumeId,
+			want: "",
+		},
+		{
+			name: "empty tags slice returns empty string",
+			tags: []string{},
+			key:  VDITagKeyVolumeId,
+			want: "",
+		},
+		{
+			name: "value containing colons is returned intact",
+			tags: []string{"k8s:someKey:a:b:c"},
+			key:  "someKey",
+			want: "a:b:c",
+		},
+		{
+			name: "tag with correct prefix but wrong key is not matched",
+			tags: []string{"k8s:pvNameExtra:pvc-x"},
+			key:  VDITagKeyPVName,
+			want: "",
+		},
+		{
+			name: "empty value is returned correctly",
+			tags: []string{"k8s:volumeId:"},
+			key:  VDITagKeyVolumeId,
+			want: "",
+		},
+		{
+			name: "returns first match when key appears more than once",
+			tags: []string{"k8s:volumeId:first", "k8s:volumeId:second"},
+			key:  VDITagKeyVolumeId,
+			want: "first",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseTagValue(tt.tags, tt.key)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BuildTagFilter
+// ---------------------------------------------------------------------------
+
+func TestBuildTagFilter(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		want  string
+	}{
+		{
+			name:  "plain UUID value — hyphens are not regex metacharacters, no escaping needed",
+			key:   VDITagKeyVolumeId,
+			value: "aaaaaaaa-0000-0000-0000-000000000001",
+			want:  `tags:/^k8s:volumeId:aaaaaaaa-0000-0000-0000-000000000001$/`,
+		},
+		{
+			name:  "PV name with hyphens — hyphens are not regex metacharacters, no escaping needed",
+			key:   VDITagKeyPVName,
+			value: "pvc-my-volume",
+			want:  `tags:/^k8s:pvName:pvc-my-volume$/`,
+		},
+		{
+			name:  "managed-by value with dot and at is escaped",
+			key:   VDITagKeyManagedBy,
+			value: "csi.xenorchestra.vates.tech@0.4.0",
+			want:  `tags:/^k8s:managedBy:csi\.xenorchestra\.vates\.tech@0\.4\.0$/`,
+		},
+		{
+			name:  "value with regex special chars is fully escaped",
+			key:   "key",
+			value: "a.b*c+d?e[f]g",
+			want:  `tags:/^k8s:key:a\.b\*c\+d\?e\[f\]g$/`,
+		},
+		{
+			name:  "empty value",
+			key:   VDITagKeyVolumeId,
+			value: "",
+			want:  `tags:/^k8s:volumeId:$/`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildTagFilter(tt.key, tt.value)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: BuildTag / ParseTagValue
+// ---------------------------------------------------------------------------
+
+func TestBuildTagParseTagValueRoundTrip(t *testing.T) {
+	pairs := []struct {
+		key   string
+		value string
+	}{
+		{VDITagKeyVolumeId, "aaaaaaaa-0000-0000-0000-000000000001"},
+		{VDITagKeyPVName, "pvc-some-persistent-volume"},
+		{VDITagKeyManagedBy, "csi.xenorchestra.vates.tech@0.4.0"},
+		{"someKey", "value:with:colons"},
+	}
+
+	for _, p := range pairs {
+		t.Run(p.key+"="+p.value, func(t *testing.T) {
+			tag := BuildTag(p.key, p.value)
+			got := ParseTagValue([]string{tag}, p.key)
+			assert.Equal(t, p.value, got, "round-trip failed for key=%q value=%q tag=%q", p.key, p.value, tag)
+		})
+	}
+}

--- a/pkg/xenorchestra-csi/clients/helpers_test.go
+++ b/pkg/xenorchestra-csi/clients/helpers_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/vatesfr/xenorchestra-go-sdk/pkg/payloads"
 )
 
 // ---------------------------------------------------------------------------
@@ -35,8 +37,8 @@ func TestBuildTag(t *testing.T) {
 		{
 			name:  "volume ID tag",
 			key:   VDITagKeyVolumeId,
-			value: "aaaaaaaa-0000-0000-0000-000000000001",
-			want:  "k8s:volumeId:aaaaaaaa-0000-0000-0000-000000000001",
+			value: "aaaaaaab-0000-0000-0000-000000000001",
+			want:  "k8s:volumeId:aaaaaaab-0000-0000-0000-000000000001",
 		},
 		{
 			name:  "PV name tag",
@@ -52,9 +54,9 @@ func TestBuildTag(t *testing.T) {
 		},
 		{
 			name:  "value with colons is preserved verbatim",
-			key:   "someKey",
+			key:   "someKey1",
 			value: "a:b:c",
-			want:  "k8s:someKey:a:b:c",
+			want:  "k8s:someKey1:a:b:c",
 		},
 		{
 			name:  "empty value",
@@ -178,8 +180,8 @@ func TestBuildTagFilter(t *testing.T) {
 		{
 			name:  "managed-by value with dot and at is escaped",
 			key:   VDITagKeyManagedBy,
-			value: "csi.xenorchestra.vates.tech@0.4.0",
-			want:  `tags:/^k8s:managedBy:csi\.xenorchestra\.vates\.tech@0\.4\.0$/`,
+			value: "csi.xenorchestra.vates.tech@0.4.1",
+			want:  `tags:/^k8s:managedBy:csi\.xenorchestra\.vates\.tech@0\.4\.1$/`,
 		},
 		{
 			name:  "value with regex special chars is fully escaped",
@@ -214,7 +216,7 @@ func TestBuildTagParseTagValueRoundTrip(t *testing.T) {
 	}{
 		{VDITagKeyVolumeId, "aaaaaaaa-0000-0000-0000-000000000001"},
 		{VDITagKeyPVName, "pvc-some-persistent-volume"},
-		{VDITagKeyManagedBy, "csi.xenorchestra.vates.tech@0.4.0"},
+		{VDITagKeyManagedBy, "csi.xenorchestra.vates.tech@0.4.2"},
 		{"someKey", "value:with:colons"},
 	}
 
@@ -225,4 +227,99 @@ func TestBuildTagParseTagValueRoundTrip(t *testing.T) {
 			assert.Equal(t, p.value, got, "round-trip failed for key=%q value=%q tag=%q", p.key, p.value, tag)
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// RecoverVolumeNameFromVDI
+// ---------------------------------------------------------------------------
+
+func TestParseVolumeNameFromVDINameDescription(t *testing.T) {
+	tests := []struct {
+		name            string
+		nameDescription string
+		want            string
+	}{
+		{
+			name:            "ExactFormat",
+			nameDescription: "VDI managed by the Kubernetes CSI; pv-name=pvc-from-description1",
+			want:            "pvc-from-description1",
+		},
+		{
+			name:            "StopsAtSpaceDelimiter",
+			nameDescription: "VDI managed by the Kubernetes CSI; pv-name=pvc-from-description2 manual-edit",
+			want:            "pvc-from-description2",
+		},
+		{
+			name:            "StopsAtSemicolonDelimiter",
+			nameDescription: "VDI managed by the Kubernetes CSI; pv-name=pvc-from-description3; manual-edit",
+			want:            "pvc-from-description3",
+		},
+		{
+			name:            "MissingPVName",
+			nameDescription: "VDI managed by the Kubernetes CSI",
+			want:            "",
+		},
+		{
+			name:            "EmptyPVName",
+			nameDescription: "VDI managed by the Kubernetes CSI; pv-name=",
+			want:            "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseVolumeNameFromVDINameDescription(tt.nameDescription)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRecoverVolumeNameFromVDI(t *testing.T) {
+	t.Run("FromNameDescription", func(t *testing.T) {
+		vdi := &payloads.VDI{
+			NameDescription: "VDI managed by the Kubernetes CSI; pv-name=pvc-from-description",
+			NameLabel:       "csi-aaaaaaaa-0000-0000-0000-000000000001-pvc-from-label",
+		}
+
+		got := recoverVolumeNameFromVDI(vdi, "aaaaaaaa-0000-0000-0000-000000000001")
+		assert.Equal(t, "pvc-from-description", got)
+	})
+
+	t.Run("FromNameDescriptionWithManualEditSuffix", func(t *testing.T) {
+		vdi := &payloads.VDI{
+			NameDescription: "VDI managed by the Kubernetes CSI; pv-name=pvc-from-description manual-edit",
+			NameLabel:       "csi-aaaaaaaa-0000-0000-0000-000000000001-pvc-from-label",
+		}
+
+		got := recoverVolumeNameFromVDI(vdi, "aaaaaaaa-0000-0000-0000-000000000001")
+		assert.Equal(t, "pvc-from-description", got)
+	})
+
+	t.Run("FromNameLabelFallback", func(t *testing.T) {
+		vdi := &payloads.VDI{
+			NameLabel: "csi-aaaaaaaa-0000-0000-0000-000000000002-pvc-from-label",
+		}
+
+		got := recoverVolumeNameFromVDI(vdi, "aaaaaaaa-0000-0000-0000-000000000002")
+		assert.Equal(t, "pvc-from-label", got)
+	})
+
+	t.Run("RejectsNameLabelWithSpace", func(t *testing.T) {
+		vdi := &payloads.VDI{
+			NameLabel: "csi-aaaaaaaa-0000-0000-0000-000000000002-pvc from label",
+		}
+
+		got := recoverVolumeNameFromVDI(vdi, "aaaaaaaa-0000-0000-0000-000000000002")
+		assert.Empty(t, got)
+	})
+
+	t.Run("EmptyWhenNotRecoverable", func(t *testing.T) {
+		vdi := &payloads.VDI{
+			NameDescription: "custom description",
+			NameLabel:       "custom-label",
+		}
+
+		got := recoverVolumeNameFromVDI(vdi, "aaaaaaaa-0000-0000-0000-000000000003")
+		assert.Empty(t, got)
+	})
 }

--- a/pkg/xenorchestra-csi/clients/mock/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/mock/xoclient.go
@@ -75,9 +75,9 @@ func (mr *MockXoClientMockRecorder) ConnectVBDToVM(ctx, vbd any) *gomock.Call {
 }
 
 // CreateNewVolume mocks base method.
-func (m *MockXoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, namePrefix string, capacityBytes int64, volumeName, createdBy, clusterTag string) (uuid.UUID, uuid.UUID, error) {
+func (m *MockXoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, namePrefix string, capacityBytes int64, volumeName, managedBy, clusterTag string) (uuid.UUID, uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNewVolume", ctx, srID, namePrefix, capacityBytes, volumeName, createdBy, clusterTag)
+	ret := m.ctrl.Call(m, "CreateNewVolume", ctx, srID, namePrefix, capacityBytes, volumeName, managedBy, clusterTag)
 	ret0, _ := ret[0].(uuid.UUID)
 	ret1, _ := ret[1].(uuid.UUID)
 	ret2, _ := ret[2].(error)
@@ -85,9 +85,9 @@ func (m *MockXoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, name
 }
 
 // CreateNewVolume indicates an expected call of CreateNewVolume.
-func (mr *MockXoClientMockRecorder) CreateNewVolume(ctx, srID, namePrefix, capacityBytes, volumeName, createdBy, clusterTag any) *gomock.Call {
+func (mr *MockXoClientMockRecorder) CreateNewVolume(ctx, srID, namePrefix, capacityBytes, volumeName, managedBy, clusterTag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewVolume", reflect.TypeOf((*MockXoClient)(nil).CreateNewVolume), ctx, srID, namePrefix, capacityBytes, volumeName, createdBy, clusterTag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewVolume", reflect.TypeOf((*MockXoClient)(nil).CreateNewVolume), ctx, srID, namePrefix, capacityBytes, volumeName, managedBy, clusterTag)
 }
 
 // DisconnectVBDFromVM mocks base method.
@@ -238,7 +238,7 @@ func (mr *MockXoClientMockRecorder) IsVDIUsedAnywhere(ctx, vdi any) *gomock.Call
 }
 
 // MigrateVDIAndWait mocks base method.
-func (m *MockXoClient) MigrateVDIAndWait(ctx context.Context, vdiID, targetSRID uuid.UUID) (uuid.UUID, error) {
+func (m *MockXoClient) MigrateVDIAndWait(ctx context.Context, vdiID payloads.VDI, targetSRID uuid.UUID) (uuid.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MigrateVDIAndWait", ctx, vdiID, targetSRID)
 	ret0, _ := ret[0].(uuid.UUID)

--- a/pkg/xenorchestra-csi/clients/mock/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/mock/xoclient.go
@@ -238,18 +238,18 @@ func (mr *MockXoClientMockRecorder) IsVDIUsedAnywhere(ctx, vdi any) *gomock.Call
 }
 
 // MigrateVDIAndWait mocks base method.
-func (m *MockXoClient) MigrateVDIAndWait(ctx context.Context, vdiID payloads.VDI, targetSRID uuid.UUID) (uuid.UUID, error) {
+func (m *MockXoClient) MigrateVDIAndWait(ctx context.Context, vdi payloads.VDI, targetSRID uuid.UUID) (uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MigrateVDIAndWait", ctx, vdiID, targetSRID)
+	ret := m.ctrl.Call(m, "MigrateVDIAndWait", ctx, vdi, targetSRID)
 	ret0, _ := ret[0].(uuid.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MigrateVDIAndWait indicates an expected call of MigrateVDIAndWait.
-func (mr *MockXoClientMockRecorder) MigrateVDIAndWait(ctx, vdiID, targetSRID any) *gomock.Call {
+func (mr *MockXoClientMockRecorder) MigrateVDIAndWait(ctx, vdi, targetSRID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateVDIAndWait", reflect.TypeOf((*MockXoClient)(nil).MigrateVDIAndWait), ctx, vdiID, targetSRID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateVDIAndWait", reflect.TypeOf((*MockXoClient)(nil).MigrateVDIAndWait), ctx, vdi, targetSRID)
 }
 
 // PBD mocks base method.

--- a/pkg/xenorchestra-csi/clients/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/xoclient.go
@@ -54,8 +54,10 @@ type XoClient interface {
 	IsSRAttachedToVMHost(ctx context.Context, vbdID uuid.UUID) error
 
 	// GetVDIByVolumeId looks up a VDI by its CSI volume ID (UUID).
-	// The ID is stored in the VDI tag "k8s:volumeId:<uuid>" at creation time
-	// and remains stable across SR migrations.
+	// Lookup order:
+	//  1. VDI tag "k8s:volumeId:<volumeId>" (primary, v0.4.0+ and migrated volumes)
+	//  2. name_label containing the volumeId (migrated v0.3.0 volumes, tag recovery)
+	//  3. Direct VDI UUID lookup (static volumes using raw VDI UUID as volumeHandle)
 	// Returns ErrVolumeNotFound if no VDI matches, ErrVolumeIdAmbiguous if multiple match.
 	GetVDIByVolumeId(ctx context.Context, volumeId string) (*payloads.VDI, error)
 
@@ -269,44 +271,57 @@ func (c xoClient) DisconnectVBDFromVM(ctx context.Context, vdi payloads.VDI, vmU
 }
 
 func (c xoClient) GetVDIByVolumeId(ctx context.Context, volumeId string) (*payloads.VDI, error) {
+	// 1. Primary: look up by VDI tag "k8s:volumeId:<volumeId>".
 	filter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
 	vdis, err := c.VDI().GetAll(ctx, 2, filter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list VDIs by volume ID %s: %w", volumeId, err)
 	}
-	switch len(vdis) {
-	case 0:
-		// Fallback: search by name_label containing the volumeId.
-		// This handles the case where tags were erased (e.g. after a XO restore).
-		// NOTE: This should be removed in a future major release once we can be sure tags are always preserved.
-		klog.V(2).InfoS("No VDI found with tag volume ID, falling back to name_label search", "volumeId", volumeId)
-		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
-		vdis, err = c.VDI().GetAll(ctx, 2, fallbackFilter)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list VDIs by name_label for volume ID %s: %w", volumeId, err)
-		}
-		switch len(vdis) {
-		case 0:
-			return nil, ErrVolumeNotFound
-		case 1:
-			// Recover VDI tags for the found VDI to ensure it can be found by volume ID in the future.
-			klog.V(2).InfoS("Found VDI by name_label fallback, recovering tags", "volumeId", volumeId, "vdiID", vdis[0].ID)
-			tagsToRecover := []string{BuildTag(VDITagKeyVolumeId, volumeId)}
-			if recoveredVolumeName := recoverVolumeNameFromVDI(vdis[0], volumeId); recoveredVolumeName != "" {
-				tagsToRecover = append(tagsToRecover, BuildTag(VDITagKeyPVName, recoveredVolumeName))
-			} else {
-				klog.V(3).InfoS("Could not recover pvName from VDI metadata during fallback", "volumeId", volumeId, "vdiID", vdis[0].ID)
-			}
-			_ = c.writeTagsToVDI(ctx, vdis[0].ID, tagsToRecover)
-			return vdis[0], nil
-		default:
-			return nil, fmt.Errorf("%w: volumeId=%s matched %d VDIs via name_label fallback", ErrVolumeIdAmbiguous, volumeId, len(vdis))
-		}
-	case 1:
+	if len(vdis) == 1 {
 		return vdis[0], nil
-	default:
-		return nil, fmt.Errorf("%w: volumeId=%s matched %d VDIs", ErrVolumeIdAmbiguous, volumeId, len(vdis))
 	}
+	if len(vdis) > 1 {
+		return nil, fmt.Errorf("%w: volumeId=%s matched %d VDIs via tag", ErrVolumeIdAmbiguous, volumeId, len(vdis))
+	}
+
+	// 2. Fallback: search by name_label containing the volumeId.
+	// This handles the case where tags were erased (e.g. after a migration).
+	klog.V(2).InfoS("No VDI found with tag volume ID, falling back to name_label search", "volumeId", volumeId)
+	fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+	vdis, err = c.VDI().GetAll(ctx, 2, fallbackFilter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list VDIs by name_label for volume ID %s: %w", volumeId, err)
+	}
+	if len(vdis) == 1 {
+		// Recover VDI tags for the found VDI to ensure it can be found by volume ID in the future.
+		klog.V(2).InfoS("Found VDI by name_label fallback, recovering tags", "volumeId", volumeId, "vdiID", vdis[0].ID)
+		c.recoverVolumeLookupTags(ctx, vdis[0], volumeId)
+		return vdis[0], nil
+	}
+	if len(vdis) > 1 {
+		return nil, fmt.Errorf("%w: volumeId=%s matched %d VDIs via name_label fallback", ErrVolumeIdAmbiguous, volumeId, len(vdis))
+	}
+
+	// 3. Final fallback: direct VDI UUID lookup for static volumes.
+	// Static provisioning uses the raw VDI UUID as volumeHandle. This lookup
+	// is intentionally last because dynamic volume handles can also be UUID-shaped,
+	// and we must avoid returning the wrong VDI.
+	if parsedUUID, err := uuid.FromString(volumeId); err == nil && parsedUUID != uuid.Nil {
+		klog.V(2).InfoS("No VDI found by name_label, falling back to direct VDI UUID lookup", "volumeId", volumeId)
+		vdi, err := c.VDI().Get(ctx, parsedUUID)
+		if err != nil {
+			if IsNotFoundError(err) {
+				return nil, ErrVolumeNotFound
+			}
+			return nil, fmt.Errorf("failed to get VDI by direct UUID %s: %w", volumeId, err)
+		}
+		// Recover the tag so future lookups hit the primary path.
+		klog.V(2).InfoS("Found VDI by direct UUID lookup, recovering tags", "volumeId", volumeId, "vdiID", vdi.ID)
+		c.recoverVolumeLookupTags(ctx, vdi, volumeId)
+		return vdi, nil
+	}
+
+	return nil, ErrVolumeNotFound
 }
 
 func (c xoClient) FindVDIByVolumeName(ctx context.Context, volumeName string) (*payloads.VDI, string, error) {
@@ -374,6 +389,16 @@ func (c xoClient) MigrateVDIAndWait(ctx context.Context, vdiID payloads.VDI, tar
 	// We need to manually copy the "k8s:volumeId:<uuid>" tag from the old VDI to the new one to ensure the new VDI can be found by volume ID after migration.
 	_ = c.writeTagsToVDI(ctx, newVDIID, oldTags)
 	return newVDIID, nil
+}
+
+func (c xoClient) recoverVolumeLookupTags(ctx context.Context, vdi *payloads.VDI, volumeId string) {
+	tagsToRecover := []string{BuildTag(VDITagKeyVolumeId, volumeId)}
+	if recoveredVolumeName := recoverVolumeNameFromVDI(vdi, volumeId); recoveredVolumeName != "" {
+		tagsToRecover = append(tagsToRecover, BuildTag(VDITagKeyPVName, recoveredVolumeName))
+	} else {
+		klog.V(3).InfoS("Could not recover pvName from VDI metadata during fallback", "volumeId", volumeId, "vdiID", vdi.ID)
+	}
+	_ = c.writeTagsToVDI(ctx, vdi.ID, tagsToRecover)
 }
 
 func (c xoClient) writeTagsToVDI(ctx context.Context, vdiID uuid.UUID, tags []string) error {

--- a/pkg/xenorchestra-csi/clients/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/xoclient.go
@@ -18,6 +18,7 @@ package clients
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -68,7 +69,7 @@ type XoClient interface {
 
 	// MigrateVDIAndWait migrates vdiID to targetSRID and blocks until the task
 	// completes. Returns the new VDI UUID assigned by XAPI after migration.
-	MigrateVDIAndWait(ctx context.Context, vdiID uuid.UUID, targetSRID uuid.UUID) (uuid.UUID, error)
+	MigrateVDIAndWait(ctx context.Context, vdiID payloads.VDI, targetSRID uuid.UUID) (uuid.UUID, error)
 }
 
 type xoClient struct {
@@ -288,6 +289,15 @@ func (c xoClient) GetVDIByVolumeId(ctx context.Context, volumeId string) (*paylo
 		case 0:
 			return nil, ErrVolumeNotFound
 		case 1:
+			// Recover VDI tags for the found VDI to ensure it can be found by volume ID in the future.
+			klog.V(2).InfoS("Found VDI by name_label fallback, recovering tags", "volumeId", volumeId, "vdiID", vdis[0].ID)
+			tagsToRecover := []string{BuildTag(VDITagKeyVolumeId, volumeId)}
+			if recoveredVolumeName := recoverVolumeNameFromVDI(vdis[0], volumeId); recoveredVolumeName != "" {
+				tagsToRecover = append(tagsToRecover, BuildTag(VDITagKeyPVName, recoveredVolumeName))
+			} else {
+				klog.V(3).InfoS("Could not recover pvName from VDI metadata during fallback", "volumeId", volumeId, "vdiID", vdis[0].ID)
+			}
+			_ = c.writeTagsToVDI(ctx, vdis[0].ID, tagsToRecover)
 			return vdis[0], nil
 		default:
 			return nil, fmt.Errorf("%w: volumeId=%s matched %d VDIs via name_label fallback", ErrVolumeIdAmbiguous, volumeId, len(vdis))
@@ -339,10 +349,14 @@ func (c xoClient) FindLocalSRsForPool(ctx context.Context, poolID uuid.UUID) ([]
 	return srs, nil
 }
 
-func (c xoClient) MigrateVDIAndWait(ctx context.Context, vdiID uuid.UUID, targetSRID uuid.UUID) (uuid.UUID, error) {
-	taskID, err := c.VDI().Migrate(ctx, vdiID, targetSRID)
+func (c xoClient) MigrateVDIAndWait(ctx context.Context, vdiID payloads.VDI, targetSRID uuid.UUID) (uuid.UUID, error) {
+	// Workaround for the tags that are not copied during migration.
+	oldTags := vdiID.Tags
+
+	klog.V(2).InfoS("Starting VDI migration", "vdiID", vdiID.ID, "fromSR", vdiID.SR, "toSR", targetSRID, "oldTags", oldTags)
+	taskID, err := c.VDI().Migrate(ctx, vdiID.ID, targetSRID)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("failed to start VDI migration (vdiID=%s targetSR=%s): %w", vdiID, targetSRID, err)
+		return uuid.Nil, fmt.Errorf("failed to start VDI migration (vdiID=%s targetSR=%s): %w", vdiID.ID, targetSRID, err)
 	}
 	task, err := c.Task().Wait(ctx, taskID)
 	if err != nil {
@@ -354,5 +368,22 @@ func (c xoClient) MigrateVDIAndWait(ctx context.Context, vdiID uuid.UUID, target
 	if task.Result.ID == uuid.Nil {
 		return uuid.Nil, fmt.Errorf("VDI migration task %s succeeded but returned no new VDI UUID", taskID)
 	}
-	return task.Result.ID, nil
+	newVDIID := task.Result.ID
+	klog.V(2).InfoS("VDI migration completed", "oldVDIID", vdiID.ID, "newVDIID", newVDIID)
+
+	// We need to manually copy the "k8s:volumeId:<uuid>" tag from the old VDI to the new one to ensure the new VDI can be found by volume ID after migration.
+	_ = c.writeTagsToVDI(ctx, newVDIID, oldTags)
+	return newVDIID, nil
+}
+
+func (c xoClient) writeTagsToVDI(ctx context.Context, vdiID uuid.UUID, tags []string) error {
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, tagPrefix+":") {
+			if err := c.VDI().AddTag(ctx, vdiID, tag); err != nil {
+				klog.ErrorS(err, "Failed to copy tag to VDI", "vdiID", vdiID, "tag", tag)
+				// Not returning an error here since the migration itself succeeded and the volume can still be found by name, but logging it for troubleshooting.
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/xenorchestra-csi/clients/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/xoclient.go
@@ -38,11 +38,11 @@ type XoClient interface {
 	ConnectVBDToVM(ctx context.Context, vbd payloads.VBD) (*payloads.VBD, error)
 	DisconnectVBDFromVM(ctx context.Context, vdi payloads.VDI, vmUUID uuid.UUID) error
 	AttachVDIToVM(ctx context.Context, vdi payloads.VDI, vmUUID uuid.UUID) (*payloads.VBD, error)
-	CreateNewVolume(ctx context.Context, srID uuid.UUID, namePrefix string, capacityBytes int64, volumeName string, createdBy string, clusterTag string) (uuid.UUID, uuid.UUID, error)
+	CreateNewVolume(ctx context.Context, srID uuid.UUID, namePrefix string, capacityBytes int64, volumeName string, managedBy string, clusterTag string) (uuid.UUID, uuid.UUID, error)
 	WaitForVDIToBeFullyAttached(ctx context.Context, vbdID uuid.UUID) (*payloads.VBD, error)
 	IsVDIUsedAnywhere(ctx context.Context, vdi *payloads.VDI) ([]*payloads.VBD, error)
 	// FindVDIByVolumeName looks up a VDI by the Kubernetes PV name stored in
-	// VDI.other_config["kubernetes_pv_name"]. It returns nil, nil when not found.
+	// the VDI tag "k8s:pvName:<volumeName>". It returns nil, nil when not found.
 	FindVDIByVolumeName(ctx context.Context, volumeName string) (*payloads.VDI, string, error)
 	// IsSRAttachedToHost checks that the given SR is connected (via a plugged PBD) to the given host.
 	// Returns nil when the SR is reachable, or a descriptive error otherwise.
@@ -53,7 +53,7 @@ type XoClient interface {
 	IsSRAttachedToVMHost(ctx context.Context, vbdID uuid.UUID) error
 
 	// GetVDIByVolumeId looks up a VDI by its CSI volume ID (UUID).
-	// The ID is stored in VDI.other_config["kubernetes_volume_id"] at creation time
+	// The ID is stored in the VDI tag "k8s:volumeId:<uuid>" at creation time
 	// and remains stable across SR migrations.
 	// Returns ErrVolumeNotFound if no VDI matches, ErrVolumeIdAmbiguous if multiple match.
 	GetVDIByVolumeId(ctx context.Context, volumeId string) (*payloads.VDI, error)
@@ -143,16 +143,19 @@ func (c xoClient) AttachVDIToVM(ctx context.Context, vdi payloads.VDI, vmUUID uu
 	return vbd, nil
 }
 
-func (c xoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, namePrefix string, capacityBytes int64, volumeName string, createdBy string, clusterTag string) (uuid.UUID, uuid.UUID, error) {
+func (c xoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, namePrefix string, capacityBytes int64, volumeName string, managedBy string, clusterTag string) (uuid.UUID, uuid.UUID, error) {
 	volumeId, err := uuid.NewV4()
 	if err != nil {
 		return uuid.Nil, uuid.Nil, fmt.Errorf("failed to generate volume ID UUID: %w", err)
 	}
 
-	otherConfig := map[string]string{
-		VDIOtherConfigKeyCreatedBy: createdBy,
-		VDIOtherConfigKeyPVName:    volumeName,
-		VDIOtherConfigKeyVolumeId:  volumeId.String(),
+	tags := []string{
+		BuildTag(VDITagKeyVolumeId, volumeId.String()),
+		BuildTag(VDITagKeyPVName, volumeName),
+		BuildTag(VDITagKeyManagedBy, managedBy),
+	}
+	if clusterTag != "" {
+		tags = append(tags, clusterTag)
 	}
 
 	vdiParams := payloads.VDICreateParams{
@@ -160,10 +163,7 @@ func (c xoClient) CreateNewVolume(ctx context.Context, srID uuid.UUID, namePrefi
 		NameLabel:       BuildVDINameLabel(namePrefix, volumeId.String(), volumeName),
 		VirtualSize:     capacityBytes,
 		NameDescription: BuildVDINameDescription(volumeName),
-		OtherConfig:     otherConfig,
-	}
-	if clusterTag != "" {
-		vdiParams.Tags = []string{clusterTag}
+		Tags:            tags,
 	}
 
 	vdiID, err := c.VDI().Create(ctx, vdiParams)
@@ -268,7 +268,7 @@ func (c xoClient) DisconnectVBDFromVM(ctx context.Context, vdi payloads.VDI, vmU
 }
 
 func (c xoClient) GetVDIByVolumeId(ctx context.Context, volumeId string) (*payloads.VDI, error) {
-	filter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+	filter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
 	vdis, err := c.VDI().GetAll(ctx, 2, filter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list VDIs by volume ID %s: %w", volumeId, err)
@@ -276,9 +276,9 @@ func (c xoClient) GetVDIByVolumeId(ctx context.Context, volumeId string) (*paylo
 	switch len(vdis) {
 	case 0:
 		// Fallback: search by name_label containing the volumeId.
-		// This handles the case where other_config was erased (e.g. after a XO restore).
-		// NOTE: This should be removed in a future major release once we can be sure other_config is always preserved.
-		klog.V(2).InfoS("No VDI found with other_config volume ID, falling back to name_label search", "volumeId", volumeId)
+		// This handles the case where tags were erased (e.g. after a XO restore).
+		// NOTE: This should be removed in a future major release once we can be sure tags are always preserved.
+		klog.V(2).InfoS("No VDI found with tag volume ID, falling back to name_label search", "volumeId", volumeId)
 		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
 		vdis, err = c.VDI().GetAll(ctx, 2, fallbackFilter)
 		if err != nil {
@@ -300,7 +300,7 @@ func (c xoClient) GetVDIByVolumeId(ctx context.Context, volumeId string) (*paylo
 }
 
 func (c xoClient) FindVDIByVolumeName(ctx context.Context, volumeName string) (*payloads.VDI, string, error) {
-	filter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyPVName, volumeName)
+	filter := BuildTagFilter(VDITagKeyPVName, volumeName)
 	vdis, err := c.VDI().GetAll(ctx, 2, filter)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to list VDIs by volume name %s: %w", volumeName, err)
@@ -309,7 +309,7 @@ func (c xoClient) FindVDIByVolumeName(ctx context.Context, volumeName string) (*
 	case 0:
 		return nil, "", ErrVolumeNotFound
 	case 1:
-		return vdis[0], vdis[0].OtherConfig[VDIOtherConfigKeyVolumeId], nil
+		return vdis[0], ParseTagValue(vdis[0].Tags, VDITagKeyVolumeId), nil
 	default:
 		return nil, "", fmt.Errorf("%w: volumeName=%s matched %d VDIs", ErrVolumeNameAmbiguous, volumeName, len(vdis))
 	}

--- a/pkg/xenorchestra-csi/clients/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/xoclient.go
@@ -69,9 +69,9 @@ type XoClient interface {
 	// the given pool. Returns an error if the API call fails or none are found.
 	FindLocalSRsForPool(ctx context.Context, poolID uuid.UUID) ([]*payloads.StorageRepository, error)
 
-	// MigrateVDIAndWait migrates vdiID to targetSRID and blocks until the task
+	// MigrateVDIAndWait migrates vdi to targetSRID and blocks until the task
 	// completes. Returns the new VDI UUID assigned by XAPI after migration.
-	MigrateVDIAndWait(ctx context.Context, vdiID payloads.VDI, targetSRID uuid.UUID) (uuid.UUID, error)
+	MigrateVDIAndWait(ctx context.Context, vdi payloads.VDI, targetSRID uuid.UUID) (uuid.UUID, error)
 }
 
 type xoClient struct {
@@ -364,14 +364,14 @@ func (c xoClient) FindLocalSRsForPool(ctx context.Context, poolID uuid.UUID) ([]
 	return srs, nil
 }
 
-func (c xoClient) MigrateVDIAndWait(ctx context.Context, vdiID payloads.VDI, targetSRID uuid.UUID) (uuid.UUID, error) {
+func (c xoClient) MigrateVDIAndWait(ctx context.Context, vdi payloads.VDI, targetSRID uuid.UUID) (uuid.UUID, error) {
 	// Workaround for the tags that are not copied during migration.
-	oldTags := vdiID.Tags
+	oldTags := vdi.Tags
 
-	klog.V(2).InfoS("Starting VDI migration", "vdiID", vdiID.ID, "fromSR", vdiID.SR, "toSR", targetSRID, "oldTags", oldTags)
-	taskID, err := c.VDI().Migrate(ctx, vdiID.ID, targetSRID)
+	klog.V(2).InfoS("Starting VDI migration", "vdiID", vdi.ID, "fromSR", vdi.SR, "toSR", targetSRID, "oldTags", oldTags)
+	taskID, err := c.VDI().Migrate(ctx, vdi.ID, targetSRID)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("failed to start VDI migration (vdiID=%s targetSR=%s): %w", vdiID.ID, targetSRID, err)
+		return uuid.Nil, fmt.Errorf("failed to start VDI migration (vdiID=%s targetSR=%s): %w", vdi.ID, targetSRID, err)
 	}
 	task, err := c.Task().Wait(ctx, taskID)
 	if err != nil {
@@ -384,10 +384,10 @@ func (c xoClient) MigrateVDIAndWait(ctx context.Context, vdiID payloads.VDI, tar
 		return uuid.Nil, fmt.Errorf("VDI migration task %s succeeded but returned no new VDI UUID", taskID)
 	}
 	newVDIID := task.Result.ID
-	klog.V(2).InfoS("VDI migration completed", "oldVDIID", vdiID.ID, "newVDIID", newVDIID)
+	klog.V(2).InfoS("VDI migration completed", "oldVDIID", vdi.ID, "newVDIID", newVDIID)
 
 	// We need to manually copy the "k8s:volumeId:<uuid>" tag from the old VDI to the new one to ensure the new VDI can be found by volume ID after migration.
-	_ = c.writeTagsToVDI(ctx, newVDIID, oldTags)
+	c.writeTagsToVDI(ctx, newVDIID, oldTags)
 	return newVDIID, nil
 }
 
@@ -398,10 +398,10 @@ func (c xoClient) recoverVolumeLookupTags(ctx context.Context, vdi *payloads.VDI
 	} else {
 		klog.V(3).InfoS("Could not recover pvName from VDI metadata during fallback", "volumeId", volumeId, "vdiID", vdi.ID)
 	}
-	_ = c.writeTagsToVDI(ctx, vdi.ID, tagsToRecover)
+	c.writeTagsToVDI(ctx, vdi.ID, tagsToRecover)
 }
 
-func (c xoClient) writeTagsToVDI(ctx context.Context, vdiID uuid.UUID, tags []string) error {
+func (c xoClient) writeTagsToVDI(ctx context.Context, vdiID uuid.UUID, tags []string) {
 	for _, tag := range tags {
 		if strings.HasPrefix(tag, tagPrefix+":") {
 			if err := c.VDI().AddTag(ctx, vdiID, tag); err != nil {
@@ -410,5 +410,5 @@ func (c xoClient) writeTagsToVDI(ctx context.Context, vdiID uuid.UUID, tags []st
 			}
 		}
 	}
-	return nil
+	return
 }

--- a/pkg/xenorchestra-csi/clients/xoclient.go
+++ b/pkg/xenorchestra-csi/clients/xoclient.go
@@ -410,5 +410,4 @@ func (c xoClient) writeTagsToVDI(ctx context.Context, vdiID uuid.UUID, tags []st
 			}
 		}
 	}
-	return
 }

--- a/pkg/xenorchestra-csi/clients/xoclient_test.go
+++ b/pkg/xenorchestra-csi/clients/xoclient_test.go
@@ -302,8 +302,8 @@ func TestGetVDIByVolumeId(t *testing.T) {
 
 		volumeId := "aaaaaaaa-0000-0000-0000-000000000017"
 		vdi := &payloads.VDI{
-			ID:            uuid.FromStringOrNil(volumeId),
-			NameLabel:     "csi-pvc-static",
+			ID:              uuid.FromStringOrNil(volumeId),
+			NameLabel:       "csi-pvc-static",
 			NameDescription: "VDI managed by the Kubernetes CSI; pv-name=pvc-static",
 		}
 		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)

--- a/pkg/xenorchestra-csi/clients/xoclient_test.go
+++ b/pkg/xenorchestra-csi/clients/xoclient_test.go
@@ -52,6 +52,9 @@ var (
 	localSRID2 = uuid.Must(uuid.FromString("bbbbbbbb-0000-0000-0000-000000000003"))
 	poolUUID   = uuid.Must(uuid.FromString("eeeeeeee-0000-0000-0000-000000000005"))
 	vdiUUID    = uuid.Must(uuid.FromString("cccccccc-0000-0000-0000-000000000003"))
+	vdiTest    = payloads.VDI{
+		ID: vdiUUID,
+	}
 	newVDIUUID = uuid.Must(uuid.FromString("dddddddd-0000-0000-0000-000000000004"))
 	taskID     = "task-abc-123"
 )
@@ -151,7 +154,7 @@ func TestMigrateVDIAndWait(t *testing.T) {
 				Result: payloads.Result{ID: newVDIUUID},
 			}, nil)
 
-		got, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+		got, err := c.MigrateVDIAndWait(context.Background(), vdiTest, localSRID)
 		require.NoError(t, err)
 		assert.Equal(t, newVDIUUID, got)
 	})
@@ -164,7 +167,7 @@ func TestMigrateVDIAndWait(t *testing.T) {
 			Migrate(gomock.Any(), vdiUUID, localSRID).
 			Return("", migrateErr)
 
-		_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+		_, err := c.MigrateVDIAndWait(context.Background(), vdiTest, localSRID)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, migrateErr)
 	})
@@ -180,7 +183,7 @@ func TestMigrateVDIAndWait(t *testing.T) {
 			Wait(gomock.Any(), taskID).
 			Return(nil, waitErr)
 
-		_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+		_, err := c.MigrateVDIAndWait(context.Background(), vdiTest, localSRID)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, waitErr)
 	})
@@ -198,7 +201,7 @@ func TestMigrateVDIAndWait(t *testing.T) {
 				Result: payloads.Result{Message: "random failure message from XAPI"},
 			}, nil)
 
-		_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+		_, err := c.MigrateVDIAndWait(context.Background(), vdiTest, localSRID)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), string(payloads.Failure))
 		assert.Contains(t, err.Error(), "random failure message from XAPI")
@@ -217,7 +220,7 @@ func TestMigrateVDIAndWait(t *testing.T) {
 				Result: payloads.Result{ID: uuid.Nil},
 			}, nil)
 
-		_, err := c.MigrateVDIAndWait(context.Background(), vdiUUID, localSRID)
+		_, err := c.MigrateVDIAndWait(context.Background(), vdiTest, localSRID)
 		require.Error(t, err)
 	})
 }
@@ -261,6 +264,12 @@ func TestGetVDIByVolumeId(t *testing.T) {
 		mockVDI.EXPECT().
 			GetAll(gomock.Any(), 2, fallbackFilter).
 			Return([]*payloads.VDI{vdi}, nil)
+		mockVDI.EXPECT().
+			AddTag(gomock.Any(), vdiUUID, BuildTag(VDITagKeyVolumeId, volumeId)).
+			Return(nil)
+		mockVDI.EXPECT().
+			AddTag(gomock.Any(), vdiUUID, BuildTag(VDITagKeyPVName, "pvc-xyz")).
+			Return(nil)
 
 		got, err := c.GetVDIByVolumeId(context.Background(), volumeId)
 		require.NoError(t, err)

--- a/pkg/xenorchestra-csi/clients/xoclient_test.go
+++ b/pkg/xenorchestra-csi/clients/xoclient_test.go
@@ -227,17 +227,15 @@ func TestMigrateVDIAndWait(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestGetVDIByVolumeId(t *testing.T) {
-	t.Run("FoundViaOtherConfig", func(t *testing.T) {
+	t.Run("FoundViaTag", func(t *testing.T) {
 		c, mockVDI := newClientWithMockVDI(t)
 
 		volumeId := "aaaaaaaa-0000-0000-0000-000000000010"
 		vdi := &payloads.VDI{
-			ID: vdiUUID,
-			OtherConfig: map[string]string{
-				VDIOtherConfigKeyVolumeId: volumeId,
-			},
+			ID:   vdiUUID,
+			Tags: []string{BuildTag(VDITagKeyVolumeId, volumeId)},
 		}
-		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
 		mockVDI.EXPECT().
 			GetAll(gomock.Any(), 2, primaryFilter).
 			Return([]*payloads.VDI{vdi}, nil)
@@ -255,7 +253,7 @@ func TestGetVDIByVolumeId(t *testing.T) {
 			ID:        vdiUUID,
 			NameLabel: "csi-" + volumeId + "-pvc-xyz",
 		}
-		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
 		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
 		mockVDI.EXPECT().
 			GetAll(gomock.Any(), 2, primaryFilter).
@@ -273,7 +271,7 @@ func TestGetVDIByVolumeId(t *testing.T) {
 		c, mockVDI := newClientWithMockVDI(t)
 
 		volumeId := "aaaaaaaa-0000-0000-0000-000000000012"
-		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
 		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
 		mockVDI.EXPECT().
 			GetAll(gomock.Any(), 2, primaryFilter).
@@ -287,11 +285,11 @@ func TestGetVDIByVolumeId(t *testing.T) {
 		assert.ErrorIs(t, err, ErrVolumeNotFound)
 	})
 
-	t.Run("AmbiguousViaOtherConfig", func(t *testing.T) {
+	t.Run("AmbiguousViaTag", func(t *testing.T) {
 		c, mockVDI := newClientWithMockVDI(t)
 
 		volumeId := "aaaaaaaa-0000-0000-0000-000000000013"
-		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
 		mockVDI.EXPECT().
 			GetAll(gomock.Any(), 2, primaryFilter).
 			Return([]*payloads.VDI{{ID: vdiUUID}, {ID: newVDIUUID}}, nil)
@@ -305,7 +303,7 @@ func TestGetVDIByVolumeId(t *testing.T) {
 		c, mockVDI := newClientWithMockVDI(t)
 
 		volumeId := "aaaaaaaa-0000-0000-0000-000000000014"
-		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
 		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
 		mockVDI.EXPECT().
 			GetAll(gomock.Any(), 2, primaryFilter).
@@ -324,7 +322,7 @@ func TestGetVDIByVolumeId(t *testing.T) {
 
 		volumeId := "aaaaaaaa-0000-0000-0000-000000000015"
 		apiErr := errors.New("connection refused")
-		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
 		mockVDI.EXPECT().
 			GetAll(gomock.Any(), 2, primaryFilter).
 			Return(nil, apiErr)
@@ -339,7 +337,7 @@ func TestGetVDIByVolumeId(t *testing.T) {
 
 		volumeId := "aaaaaaaa-0000-0000-0000-000000000016"
 		apiErr := errors.New("timeout")
-		primaryFilter := fmt.Sprintf("other_config:%s:%s", VDIOtherConfigKeyVolumeId, volumeId)
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
 		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
 		mockVDI.EXPECT().
 			GetAll(gomock.Any(), 2, primaryFilter).
@@ -351,6 +349,93 @@ func TestGetVDIByVolumeId(t *testing.T) {
 		_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, apiErr)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// FindVDIByVolumeName
+// ---------------------------------------------------------------------------
+
+func TestFindVDIByVolumeName(t *testing.T) {
+	const volumeName = "pvc-my-volume"
+	volumeId := "aaaaaaaa-0000-0000-0000-000000000020"
+
+	t.Run("Found", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
+
+		vdi := &payloads.VDI{
+			ID: vdiUUID,
+			Tags: []string{
+				BuildTag(VDITagKeyPVName, volumeName),
+				BuildTag(VDITagKeyVolumeId, volumeId),
+			},
+		}
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, BuildTagFilter(VDITagKeyPVName, volumeName)).
+			Return([]*payloads.VDI{vdi}, nil)
+
+		gotVDI, gotId, err := c.FindVDIByVolumeName(context.Background(), volumeName)
+		require.NoError(t, err)
+		assert.Equal(t, vdi, gotVDI)
+		assert.Equal(t, volumeId, gotId)
+	})
+
+	t.Run("FoundButMissingVolumeIdTag", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
+
+		// VDI has the pvName tag but no volumeId tag — ParseTagValue returns "".
+		vdi := &payloads.VDI{
+			ID:   vdiUUID,
+			Tags: []string{BuildTag(VDITagKeyPVName, volumeName)},
+		}
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, BuildTagFilter(VDITagKeyPVName, volumeName)).
+			Return([]*payloads.VDI{vdi}, nil)
+
+		gotVDI, gotId, err := c.FindVDIByVolumeName(context.Background(), volumeName)
+		require.NoError(t, err)
+		assert.Equal(t, vdi, gotVDI)
+		assert.Empty(t, gotId)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
+
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, BuildTagFilter(VDITagKeyPVName, volumeName)).
+			Return([]*payloads.VDI{}, nil)
+
+		gotVDI, gotId, err := c.FindVDIByVolumeName(context.Background(), volumeName)
+		require.ErrorIs(t, err, ErrVolumeNotFound)
+		assert.Nil(t, gotVDI)
+		assert.Empty(t, gotId)
+	})
+
+	t.Run("Ambiguous", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
+
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, BuildTagFilter(VDITagKeyPVName, volumeName)).
+			Return([]*payloads.VDI{{ID: vdiUUID}, {ID: newVDIUUID}}, nil)
+
+		gotVDI, gotId, err := c.FindVDIByVolumeName(context.Background(), volumeName)
+		require.ErrorIs(t, err, ErrVolumeNameAmbiguous)
+		assert.Nil(t, gotVDI)
+		assert.Empty(t, gotId)
+	})
+
+	t.Run("APIError", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
+
+		apiErr := errors.New("connection refused")
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, BuildTagFilter(VDITagKeyPVName, volumeName)).
+			Return(nil, apiErr)
+
+		gotVDI, gotId, err := c.FindVDIByVolumeName(context.Background(), volumeName)
+		require.ErrorIs(t, err, apiErr)
+		assert.Nil(t, gotVDI)
+		assert.Empty(t, gotId)
 	})
 }
 

--- a/pkg/xenorchestra-csi/clients/xoclient_test.go
+++ b/pkg/xenorchestra-csi/clients/xoclient_test.go
@@ -276,10 +276,106 @@ func TestGetVDIByVolumeId(t *testing.T) {
 		assert.Equal(t, vdi, got)
 	})
 
-	t.Run("NotFoundInBothLookups", func(t *testing.T) {
+	t.Run("NotFoundInAllLookups", func(t *testing.T) {
 		c, mockVDI := newClientWithMockVDI(t)
 
 		volumeId := "aaaaaaaa-0000-0000-0000-000000000012"
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
+		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, fallbackFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			Get(gomock.Any(), uuid.FromStringOrNil(volumeId)).
+			Return(nil, fmt.Errorf("API error: 404 Not Found"))
+
+		_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrVolumeNotFound)
+	})
+
+	t.Run("FoundViaDirectUUID", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
+
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000017"
+		vdi := &payloads.VDI{
+			ID:            uuid.FromStringOrNil(volumeId),
+			NameLabel:     "csi-pvc-static",
+			NameDescription: "VDI managed by the Kubernetes CSI; pv-name=pvc-static",
+		}
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
+		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, fallbackFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			Get(gomock.Any(), uuid.FromStringOrNil(volumeId)).
+			Return(vdi, nil)
+		mockVDI.EXPECT().
+			AddTag(gomock.Any(), vdi.ID, BuildTag(VDITagKeyVolumeId, volumeId)).
+			Return(nil)
+		mockVDI.EXPECT().
+			AddTag(gomock.Any(), vdi.ID, BuildTag(VDITagKeyPVName, "pvc-static")).
+			Return(nil)
+
+		got, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.NoError(t, err)
+		assert.Equal(t, vdi, got)
+	})
+
+	t.Run("DirectUUIDNotFound", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
+
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000018"
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
+		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, fallbackFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			Get(gomock.Any(), uuid.FromStringOrNil(volumeId)).
+			Return(nil, fmt.Errorf("API error: 404 Not Found"))
+
+		_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrVolumeNotFound)
+	})
+
+	t.Run("DirectUUIDAPIError", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
+
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000019"
+		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
+		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
+		apiErr := errors.New("connection refused")
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, primaryFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			GetAll(gomock.Any(), 2, fallbackFilter).
+			Return([]*payloads.VDI{}, nil)
+		mockVDI.EXPECT().
+			Get(gomock.Any(), uuid.FromStringOrNil(volumeId)).
+			Return(nil, apiErr)
+
+		_, err := c.GetVDIByVolumeId(context.Background(), volumeId)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, apiErr)
+	})
+
+	t.Run("NonUUIDVolumeIdSkipsDirectLookup", func(t *testing.T) {
+		c, mockVDI := newClientWithMockVDI(t)
+
+		volumeId := "not-a-uuid"
 		primaryFilter := BuildTagFilter(VDITagKeyVolumeId, volumeId)
 		fallbackFilter := fmt.Sprintf("name_label:%s", volumeId)
 		mockVDI.EXPECT().

--- a/pkg/xenorchestra-csi/clients/xoclient_test.go
+++ b/pkg/xenorchestra-csi/clients/xoclient_test.go
@@ -223,6 +223,70 @@ func TestMigrateVDIAndWait(t *testing.T) {
 		_, err := c.MigrateVDIAndWait(context.Background(), vdiTest, localSRID)
 		require.Error(t, err)
 	})
+
+	t.Run("CopiesTagsToNewVDI", func(t *testing.T) {
+		c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
+
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000030"
+		volumeName := "pvc-tag-copy"
+		vdiWithTags := payloads.VDI{
+			ID: vdiUUID,
+			Tags: []string{
+				BuildTag(VDITagKeyVolumeId, volumeId),
+				BuildTag(VDITagKeyPVName, volumeName),
+				"some-other-tag",
+			},
+		}
+
+		mockVDI.EXPECT().
+			Migrate(gomock.Any(), vdiUUID, localSRID).
+			Return(taskID, nil)
+		mockTask.EXPECT().
+			Wait(gomock.Any(), taskID).
+			Return(&payloads.Task{
+				Status: payloads.Success,
+				Result: payloads.Result{ID: newVDIUUID},
+			}, nil)
+		mockVDI.EXPECT().
+			AddTag(gomock.Any(), newVDIUUID, BuildTag(VDITagKeyVolumeId, volumeId)).
+			Return(nil)
+		mockVDI.EXPECT().
+			AddTag(gomock.Any(), newVDIUUID, BuildTag(VDITagKeyPVName, volumeName)).
+			Return(nil)
+
+		got, err := c.MigrateVDIAndWait(context.Background(), vdiWithTags, localSRID)
+		require.NoError(t, err)
+		assert.Equal(t, newVDIUUID, got)
+	})
+
+	t.Run("AddTagErrorDoesNotFailMigration", func(t *testing.T) {
+		c, mockVDI, mockTask := newClientWithMockVDIAndTask(t)
+
+		volumeId := "aaaaaaaa-0000-0000-0000-000000000031"
+		vdiWithTags := payloads.VDI{
+			ID: vdiUUID,
+			Tags: []string{
+				BuildTag(VDITagKeyVolumeId, volumeId),
+			},
+		}
+
+		mockVDI.EXPECT().
+			Migrate(gomock.Any(), vdiUUID, localSRID).
+			Return(taskID, nil)
+		mockTask.EXPECT().
+			Wait(gomock.Any(), taskID).
+			Return(&payloads.Task{
+				Status: payloads.Success,
+				Result: payloads.Result{ID: newVDIUUID},
+			}, nil)
+		mockVDI.EXPECT().
+			AddTag(gomock.Any(), newVDIUUID, BuildTag(VDITagKeyVolumeId, volumeId)).
+			Return(errors.New("tag write failed"))
+
+		got, err := c.MigrateVDIAndWait(context.Background(), vdiWithTags, localSRID)
+		require.NoError(t, err)
+		assert.Equal(t, newVDIUUID, got)
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/xenorchestra-csi/controllerserver.go
+++ b/pkg/xenorchestra-csi/controllerserver.go
@@ -148,7 +148,7 @@ func (driver *xenorchestraCSIDriver) ControllerPublishVolume(ctx context.Context
 		if vdi.SR != localSR.ID {
 			klog.V(2).InfoS("Migrating VDI to local SR",
 				"vdiID", vdi.ID, "fromSR", vdi.SR, "toSR", localSR.ID)
-			newVDIUUID, err := driver.xoClient.MigrateVDIAndWait(ctx, vdi.ID, localSR.ID)
+			newVDIUUID, err := driver.xoClient.MigrateVDIAndWait(ctx, *vdi, localSR.ID)
 			if err != nil {
 				klog.ErrorS(err, "Failed to migrate VDI to local SR", "vdiID", vdi.ID, "localSRID", localSR.ID)
 				return nil, status.Errorf(codes.Internal,

--- a/pkg/xenorchestra-csi/controllerserver.go
+++ b/pkg/xenorchestra-csi/controllerserver.go
@@ -419,7 +419,7 @@ func (driver *xenorchestraCSIDriver) CreateVolume(ctx context.Context, req *csi.
 		}
 		// Recover the stable volume ID stored at creation time.
 		if existingId == "" {
-			return nil, status.Errorf(codes.Internal, "existing VDI %s is missing volume ID in other_config", existingVDI.ID)
+			return nil, status.Errorf(codes.Internal, "existing VDI %s is missing volume ID in tags", existingVDI.ID)
 		}
 		klog.V(5).InfoS("Volume already exists, returning existing VDI", "vdiID", existingVDI.ID, "volumeId", existingId)
 		return &csi.CreateVolumeResponse{
@@ -432,7 +432,7 @@ func (driver *xenorchestraCSIDriver) CreateVolume(ctx context.Context, req *csi.
 		}, nil
 	}
 
-	vdiID, volumeID, err := driver.xoClient.CreateNewVolume(ctx, sr.ID, driver.vdiNamePrefix, capacityBytes, volumeName, DriverName, driver.clusterTag)
+	vdiID, volumeID, err := driver.xoClient.CreateNewVolume(ctx, sr.ID, driver.vdiNamePrefix, capacityBytes, volumeName, driver.Name+"@"+driver.Version, driver.clusterTag)
 	if err != nil {
 		klog.ErrorS(err, "Failed to create VDI", "volumeName", volumeName, "capacityBytes", capacityBytes)
 		return nil, status.Errorf(codes.Internal, "Failed to create VDI: %v", err)

--- a/pkg/xenorchestra-csi/controllerserver.go
+++ b/pkg/xenorchestra-csi/controllerserver.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"slices"
-	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/gofrs/uuid"
@@ -492,7 +491,7 @@ func (driver *xenorchestraCSIDriver) DeleteVolume(ctx context.Context, req *csi.
 	}
 
 	if err := driver.xoClient.VDI().Delete(ctx, vdi.ID); err != nil {
-		if isNotFoundError(err) {
+		if clients.IsNotFoundError(err) {
 			// Deleted by a concurrent call between our lookup and Delete
 			klog.V(4).InfoS("VDI not found during delete call, already deleted by concurrent call", "volumeID", volumeID, "vdiID", vdi.ID)
 			return &csi.DeleteVolumeResponse{}, nil
@@ -588,11 +587,4 @@ func publishContextFromVBD(vbd payloads.VBD) map[string]string {
 		"device": *vbd.Device,
 		"vbd":    vbd.ID.String(),
 	}
-}
-
-// isNotFoundError reports whether err is an HTTP 404 from the Xen Orchestra REST
-// API. The SDK does not expose a dedicated sentinel; errors follow the pattern
-// "API error: 404 Not Found - <body>".
-func isNotFoundError(err error) bool {
-	return strings.Contains(err.Error(), "API error: 404 Not Found")
 }

--- a/test/sanity/fakedriver_test.go
+++ b/test/sanity/fakedriver_test.go
@@ -55,9 +55,9 @@ func NewFakeDriver(t *testing.T, options *xenorchestracsi.DriverOptions, fakeMou
 				SR:        srID,
 				NameLabel: clients.BuildVDINameLabel(namePrefix, volumeId.String(), volumeName),
 				Size:      capacityBytes,
-				OtherConfig: map[string]string{
-					clients.VDIOtherConfigKeyPVName:   volumeName,
-					clients.VDIOtherConfigKeyVolumeId: volumeId.String(),
+				Tags: []string{
+					clients.BuildTag(clients.VDITagKeyPVName, volumeName),
+					clients.BuildTag(clients.VDITagKeyVolumeId, volumeId.String()),
 				},
 				PoolID: uuid.FromStringOrNil(stub.PoolId),
 			}
@@ -72,7 +72,7 @@ func NewFakeDriver(t *testing.T, options *xenorchestracsi.DriverOptions, fakeMou
 
 		var matched *payloads.VDI
 		for _, vdi := range vdiStore.byID {
-			if vdi.OtherConfig[clients.VDIOtherConfigKeyPVName] != volumeName {
+			if clients.ParseTagValue(vdi.Tags, clients.VDITagKeyPVName) != volumeName {
 				continue
 			}
 			if matched != nil {
@@ -86,7 +86,7 @@ func NewFakeDriver(t *testing.T, options *xenorchestracsi.DriverOptions, fakeMou
 			return nil, "", clients.ErrVolumeNotFound
 		}
 
-		return matched, matched.OtherConfig[clients.VDIOtherConfigKeyVolumeId], nil
+		return matched, clients.ParseTagValue(matched.Tags, clients.VDITagKeyVolumeId), nil
 	}).AnyTimes()
 	mockXoClient.EXPECT().GetVDIByVolumeId(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, volumeId string) (*payloads.VDI, error) {
 		vdiStore.RLock()
@@ -94,7 +94,7 @@ func NewFakeDriver(t *testing.T, options *xenorchestracsi.DriverOptions, fakeMou
 
 		var matched *payloads.VDI
 		for _, vdi := range vdiStore.byID {
-			if vdi.OtherConfig[clients.VDIOtherConfigKeyVolumeId] != volumeId {
+			if clients.ParseTagValue(vdi.Tags, clients.VDITagKeyVolumeId) != volumeId {
 				continue
 			}
 			if matched != nil {


### PR DESCRIPTION
## Summary
- replace deprecated "other-config"-based VDI lookup with tags
- update docs and migration guidance for the new lookup path
- add and adjust tests around tag-based identification and recovery
- add tag recovery after a fallback lookup
- fix static provisioning volume that was broken with "other-config"-based lookup

