### PR TITLE
feat: restrict Xen Orchestra access to CSI controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ A Container Storage Interface (CSI) driver that provides persistent storage for 
 
 This repository hosts the CSI driver and all of its build and dependent configuration files to deploy the driver.
 
-The Xen Orchestra CCM is **required** when using the default
-`--node-metadata-source=kubernetes` mode. Without it, `spec.providerID` is not set
+The Xen Orchestra CCM is **required**. Without it, `spec.providerID` is not set
 on Node objects, `NodeGetInfo` fails, and the node-driver-registrar enters
 **CrashLoopBackOff** — the CSI node plugin never registers with kubelet and no
-volume operations are possible on that node. Use `--node-metadata-source=xo-api` if
-you cannot run the CCM (see [Topology and Placement](docs/topology.md)).
+volume operations are possible on that node (see [Topology and Placement](docs/topology.md)).
 
 * csi plugin name: `csi.xenorchestra.vates.tech`
 * supported accessModes: `ReadWriteOnce`
@@ -31,7 +29,7 @@ you cannot run the CCM (see [Topology and Placement](docs/topology.md)).
 
 * XenOrchestra version **6.4+**
 * XCP-ng version 8.3+
-* Network connectivity between Kubernetes nodes and XO API
+* Network connectivity between the CSI controller pod and the XO API
 
 ## Documentation
 
@@ -79,7 +77,7 @@ for full details and manual recovery steps.
 An example of an install with kubectl can be found in the './deploy' folder. You may need to adjust this file to fit your actual installation; see below for more information.
 
 ### Prerequisites
-* The driver depends on the CCM credentials config secret ([See here](https://github.com/vatesfr/xenorchestra-cloud-controller-manager/blob/main/docs/install.md#deploy-ccm)).
+* The controller deployment depends on the CCM credentials config secret ([See here](https://github.com/vatesfr/xenorchestra-cloud-controller-manager/blob/main/docs/install.md#deploy-ccm)).
 
 ### Quick Start with the PoC
 

--- a/deploy/csi-xenorchestra-controller-dev.yaml
+++ b/deploy/csi-xenorchestra-controller-dev.yaml
@@ -70,6 +70,7 @@ spec:
           imagePullPolicy: Always
           args:
             - "--v=5"
+            - "--mode=controller"
             - "--endpoint=unix:///csi/csi.sock"
             - "--node-name=$(KUBE_NODE_NAME)"
             - "--config-file=/etc/xenorchestra/config.yaml"
@@ -156,6 +157,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
+            - "--http-endpoint=:29607"
             - "--retry-interval-max=30s"
             - "--timeout=10m"
           imagePullPolicy: "IfNotPresent"

--- a/deploy/csi-xenorchestra-controller.yaml
+++ b/deploy/csi-xenorchestra-controller.yaml
@@ -67,6 +67,7 @@ spec:
           imagePullPolicy: Always # TODO: Change to IfNotPresent for prod
           args:
             - "--v=5"
+            - "--mode=controller"
             - "--endpoint=unix:///csi/csi.sock"
             - "--node-name=$(KUBE_NODE_NAME)"
             - "--config-file=/etc/xenorchestra/config.yaml"
@@ -149,6 +150,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
+            - "--http-endpoint=:29607"
           imagePullPolicy: "IfNotPresent"
           livenessProbe:
             failureThreshold: 1

--- a/deploy/csi-xenorchestra-node-single.yaml
+++ b/deploy/csi-xenorchestra-node-single.yaml
@@ -79,13 +79,9 @@ spec:
           imagePullPolicy: Always # TODO: Change to IfNotPresent for prod
           args:
             - "--v=5"
+            - "--mode=node"
             - "--endpoint=unix:///csi/csi.sock"
             - "--node-name=$(KUBE_NODE_NAME)"
-            - "--config-file=/etc/xenorchestra/config.yaml"
-            # node-metadata-source controls how the pool ID and VM identity are resolved.
-            # kubernetes (default): reads from node labels set by the XenOrchestra CCM.
-            # xo-api: queries the XenOrchestra API directly; use when CCM is not installed.
-            - "--node-metadata-source=kubernetes"
             - "--cluster-tag=k8s-managed"
           ports:
             - containerPort: 29603
@@ -120,9 +116,6 @@ spec:
               name: mountpoint-dir
             - mountPath: /dev
               name: device-dir
-            - mountPath: /etc/xenorchestra
-              name: xo-cloud-config
-              readOnly: true
       volumes:
         - hostPath:
             path: /var/snap/microk8s/common/var/lib/kubelet/plugins/csi.xenorchestra.vates.tech
@@ -140,7 +133,3 @@ spec:
             path: /dev
             type: Directory
           name: device-dir
-        - name: xo-cloud-config
-          secret:
-            secretName: xenorchestra-cloud-controller-manager
-            defaultMode: 416

--- a/deploy/csi-xenorchestra-node.yaml
+++ b/deploy/csi-xenorchestra-node.yaml
@@ -78,13 +78,9 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"
+            - "--mode=node"
             - "--endpoint=unix:///csi/csi.sock"
             - "--node-name=$(KUBE_NODE_NAME)"
-            - "--config-file=/etc/xenorchestra/config.yaml"
-            # node-metadata-source controls how the pool ID and VM identity are resolved.
-            # kubernetes (default): reads from node labels set by the XenOrchestra CCM.
-            # xo-api: queries the XenOrchestra API directly; use when CCM is not installed.
-            - "--node-metadata-source=kubernetes"
             - "--cluster-tag=k8s-managed"
           ports:
             - containerPort: 29603
@@ -118,9 +114,6 @@ spec:
               name: mountpoint-dir
             - mountPath: /dev
               name: device-dir
-            - mountPath: /etc/xenorchestra
-              name: xo-cloud-config
-              readOnly: true
           resources:
             limits:
               memory: 1000Mi
@@ -144,10 +137,4 @@ spec:
             path: /dev
             type: Directory
           name: device-dir
-        - name: xo-cloud-config
-          secret:
-            secretName: xenorchestra-cloud-controller-manager
-            defaultMode: 416
 ---
-
-

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ This guide walks you through installing the XenOrchestra CSI driver on a Kuberne
 | Xen Orchestra | 5.110.1+ |
 | Kubernetes | 1.26+ |
 
-Network connectivity is required between every Kubernetes node and the Xen Orchestra API endpoint.
+Network connectivity is required between the CSI controller pod and the Xen Orchestra API endpoint.
 
 ### Kubernetes tooling
 
@@ -25,8 +25,7 @@ Network connectivity is required between every Kubernetes node and the Xen Orche
 
 ### XenOrchestra Cloud Controller Manager (CCM)
 
-The CCM is **required** when using the CSI driver with the default
-`--node-metadata-source=kubernetes` mode. The CCM sets `spec.providerID` on each
+The CCM is **required** for the CSI node plugin. The CCM sets `spec.providerID` on each
 Kubernetes Node object. The CSI node plugin reads this field at startup to resolve
 the pool ID and VM UUID, then returns them from `NodeGetInfo` so that kubelet can
 register the driver and write the `topology.k8s.xenorchestra/pool_id` label.
@@ -37,13 +36,9 @@ The CSI node plugin is never registered with kubelet on that node: no volume can
 staged, published, or unpublished. The `topology.k8s.xenorchestra/pool_id` label is
 never written to the Node object.
 
-If you cannot run the CCM, use `--node-metadata-source=xo-api` instead — the driver
-will resolve the pool ID directly from the XenOrchestra API without depending on
-`spec.providerID`.
-
-The CSI driver reuses the same credentials secret as the CCM. If the CCM is already
+The CSI controller reuses the same credentials secret as the CCM. If the CCM is already
 installed you can skip the [credentials step](#2-create-the-credentials-secret)
-below.
+below. The node plugin does not mount or read this secret.
 
 See the [CCM install guide](https://github.com/vatesfr/xenorchestra-cloud-controller-manager/blob/main/docs/install.md)
 for setup instructions, and [docs/topology.md](topology.md) for a detailed
@@ -68,7 +63,7 @@ kubectl -n kube-system create secret docker-registry regcred \
 
 ### 2. Create the credentials secret
 
-The driver authenticates to Xen Orchestra using a YAML config file stored as a Kubernetes secret.
+The controller authenticates to Xen Orchestra using a YAML config file stored as a Kubernetes secret.
 
 Create a file named `xo-config.yaml`:
 
@@ -495,12 +490,16 @@ csi.xenorchestra.vates.tech
 
 These flags are passed as container arguments in the controller/node deployment manifests.
 
+The driver supports two deployment modes:
+- `--mode=controller`: the controller deployment. It exposes Identity, Controller, and Node services.
+- `--mode=node`: the node deployment. It exposes Identity and Node services only, and does not load XO credentials.
+
 | Flag | Description | Default |
 | ---- | ----------- | ------- |
+| `--mode` | Driver service mode: `controller` or `node` | `controller` |
 | `--driver-name` | CSI driver name registered with Kubernetes | `csi.xenorchestra.vates.tech` |
 | `--endpoint` | CSI gRPC endpoint | `unix://tmp/csi.sock` |
-| `--config-file` | Path to the XO credentials config file mounted in the pod | `/etc/xenorchestra/config.yaml` |
+| `--config-file` | Path to the XO credentials config file mounted in the controller pod | `/etc/xenorchestra/config.yaml` |
 | `--vdi-name-prefix` | Prefix prepended to the Kubernetes volume name when labelling VDIs in XO | `csi-` |
 | `--cluster-tag` | Tag added to every VDI at creation; `ListVolumes` only returns VDIs carrying this tag. Set to `""` to disable tagging and filtering. | `k8s-managed` |
 | `--xo-client-timeout` | HTTP timeout for XenOrchestra API requests. Defaults to `30s`, increase for large pools or slow connections. | `30s` |
-| `--node-metadata-source` | How the node plugin resolves the pool ID and VM identity: `kubernetes` (reads `spec.providerID`, requires CCM) or `xo-api` (queries XO directly) | `kubernetes` |

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -100,20 +100,9 @@ topology.k8s.xenorchestra/host_name_label = <name>
 
 ### Is the CCM mandatory?
 
-The answer depends on which `--node-metadata-source` mode is configured for the
-node plugin. The flag is set in the node DaemonSet arguments.
-
-| `--node-metadata-source` | CCM required? | How pool_id is resolved |
-| ------------------------ | ------------- | ----------------------- |
-| `kubernetes` **(default)** | **Yes** | Reads the `ProviderID` set by the CCM on the Node object. If it is absent, `NodeGetInfo` fails and the node plugin cannot register with kubelet. |
-| `xo-api` | No | Queries the XenOrchestra API directly at startup to resolve the pool ID and VM UUID from the node name. |
-
-#### Choosing the right mode
-
-```
---node-metadata-source=kubernetes   # recommended when CCM is running
---node-metadata-source=xo-api       # use this when CCM is not installed
-```
+Yes. The node plugin resolves pool topology and VM identity from the `ProviderID`
+set by the CCM on the Node object. If it is absent, `NodeGetInfo` fails and the
+node plugin cannot register with kubelet.
 
 When using **`NodeMetadataFromKubernetes`** without the CCM, `spec.providerID` on the
 Node object is empty. `GetNodeMetadata()` calls `ParseProviderID("")`, which returns

--- a/pkg/xenorchestra-csi/clients/node_metadata.go
+++ b/pkg/xenorchestra-csi/clients/node_metadata.go
@@ -62,37 +62,3 @@ func (n *NodeMetadataFromKubernetes) GetNodeMetadata() (*NodeMetadata, error) {
 		PoolId: poolId.String(),
 	}, nil
 }
-
-// NodeMetadataFromXoClient uses the XoClient to get all needed metadata.
-type NodeMetadataFromXoClient struct {
-	kclient  kclient.Interface
-	xoClient *xok8s.XoClient
-	nodeName string
-}
-
-func NewNodeMetadataFromXoClient(kubeClient kclient.Interface, xoClient *xok8s.XoClient, nodeName string) *NodeMetadataFromXoClient {
-	return &NodeMetadataFromXoClient{
-		xoClient: xoClient,
-		kclient:  kubeClient,
-		nodeName: nodeName,
-	}
-}
-
-// GetNodeMetadata retrieves node identity and topology metadata directly from
-// the XenOrchestra API. This implementation does not depend on the CCM having
-// labeled the node beforehand; it resolves the pool ID by querying XO at startup.
-func (n *NodeMetadataFromXoClient) GetNodeMetadata() (*NodeMetadata, error) {
-	node, err := n.kclient.CoreV1().Nodes().Get(context.Background(), n.nodeName, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node: %w", err)
-	}
-	vm, poolID, err := n.xoClient.FindVMByNode(context.Background(), node)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find VM by node: %w", err)
-	}
-
-	return &NodeMetadata{
-		NodeId: vm.ID.String(),
-		PoolId: poolID.String(),
-	}, nil
-}

--- a/pkg/xenorchestra-csi/driveroptions.go
+++ b/pkg/xenorchestra-csi/driveroptions.go
@@ -21,31 +21,23 @@ import (
 	"time"
 )
 
-// NodeMetadataSource controls how the CSI node plugin resolves pool ID and VM
-// identity at startup. See docs/topology.md for details.
-type NodeMetadataSource string
+// DriverMode controls which CSI services the process exposes.
+type DriverMode string
 
 const (
-	// NodeMetadataSourceKubernetes reads the pool ID from the node label set by the
-	// XenOrchestra CCM (topology.k8s.xenorchestra/pool_id) and the VM UUID from the
-	// node's ProviderID. This is the recommended mode when the CCM is installed.
-	NodeMetadataSourceKubernetes NodeMetadataSource = "kubernetes"
-
-	// NodeMetadataSourceXoAPI queries the XenOrchestra API directly at startup to
-	// resolve the pool ID and VM UUID. Use this mode when the CCM is not installed.
-	NodeMetadataSourceXoAPI NodeMetadataSource = "xo-api"
+	DriverModeController DriverMode = "controller"
+	DriverModeNode       DriverMode = "node"
 )
 
 // DriverOptions defines driver parameters specified in driver deployment
 type DriverOptions struct {
 	// Common options
+	Mode       DriverMode
 	NodeName   string
 	DriverName string
 	Endpoint   string
 	// XO Configuration
 	ConfigFile string
-	// NodeMetadataSource selects how the node plugin resolves pool ID and VM identity.
-	NodeMetadataSource NodeMetadataSource
 	// VDINamePrefix is prepended to the VDI name label in Xen Orchestra.
 	// See xenorchestracsi.BuildVDINameLabel for the full format.
 	VDINamePrefix string
@@ -70,10 +62,27 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ExitOnError)
 	// Set default before registering the flag so the field is populated even if
 	// the flag is never passed on the command line.
-	o.NodeMetadataSource = NodeMetadataSourceKubernetes
+	o.Mode = DriverModeController
 	o.VDINamePrefix = DefaultVDINamePrefix
 	o.ClusterTag = DefaultClusterTag
 	o.KubernetesPoolTag = DefaultKubernetesPoolTag
+	fs.Func("mode",
+		`CSI service mode exposed by this process.
+Allowed values:
+	  controller   Expose Identity, Controller, and Node services.
+	  node         Expose the Identity and Node services.`,
+		func(v string) error {
+			mode := DriverMode(v)
+			switch mode {
+			case DriverModeController, DriverModeNode:
+				o.Mode = mode
+				return nil
+			default:
+				return fmt.Errorf("invalid mode %q: must be %q or %q",
+					v, DriverModeController, DriverModeNode)
+			}
+		},
+	)
 	fs.StringVar(&o.NodeName, "node-name", "", "Node name")
 	fs.StringVar(&o.DriverName, "driver-name", DriverName, "Driver name")
 	fs.StringVar(&o.Endpoint, "endpoint", "unix://tmp/csi.sock", "CSI endpoint")
@@ -89,24 +98,5 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 			"Used when no poolId or topology constraints are provided.")
 	fs.DurationVar(&o.XoClientTimeout, "xo-client-timeout", 30*time.Second,
 		"HTTP timeout for XenOrchestra API requests (e.g. \"30s\").")
-	fs.Func("node-metadata-source",
-		`Source used by the node plugin to resolve pool ID and VM identity.
-Allowed values:
-  kubernetes  (default) Read pool ID from the node label set by the XenOrchestra CCM.
-              Requires the CCM to be installed and running in the cluster.
-  xo-api      Query the XenOrchestra API directly at startup.
-              Use this mode when the CCM is not installed.`,
-		func(v string) error {
-			src := NodeMetadataSource(v)
-			switch src {
-			case NodeMetadataSourceKubernetes, NodeMetadataSourceXoAPI:
-				o.NodeMetadataSource = src
-				return nil
-			default:
-				return fmt.Errorf("invalid node-metadata-source %q: must be %q or %q",
-					v, NodeMetadataSourceKubernetes, NodeMetadataSourceXoAPI)
-			}
-		},
-	)
 	return fs
 }

--- a/pkg/xenorchestra-csi/identityserver.go
+++ b/pkg/xenorchestra-csi/identityserver.go
@@ -32,17 +32,19 @@ func (driver *xenorchestraCSIDriver) GetPluginCapabilities(context.Context, *csi
 		{
 			Type: &csi.PluginCapability_Service_{
 				Service: &csi.PluginCapability_Service{
-					Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
-				},
-			},
-		},
-		{
-			Type: &csi.PluginCapability_Service_{
-				Service: &csi.PluginCapability_Service{
 					Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
 				},
 			},
 		},
+	}
+	if driver.mode != DriverModeNode {
+		caps = append([]*csi.PluginCapability{{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
+				},
+			},
+		}}, caps...)
 	}
 
 	return &csi.GetPluginCapabilitiesResponse{Capabilities: caps}, nil

--- a/pkg/xenorchestra-csi/nodeserver.go
+++ b/pkg/xenorchestra-csi/nodeserver.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/gofrs/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -234,21 +233,6 @@ func (driver *xenorchestraCSIDriver) NodeStageVolume(ctx context.Context, req *c
 	if currentDevice == device {
 		klog.V(2).Info("NodeStageVolume: volume already staged", "device", device, "target", stagingTarget)
 		return &csi.NodeStageVolumeResponse{}, nil
-	}
-
-	// Verify the SR backing this VBD is connected to the host where the VM is running.
-	// XenOrchestra may report a VDI as attached and provide a device name, but if the SR
-	// is not connected to the XCP-ng host the block device will not appear in /dev/.
-	vbdIDStr := req.GetPublishContext()["vbd"]
-	if vbdIDStr == "" {
-		return nil, status.Errorf(codes.InvalidArgument, "vbd is not set in publish context")
-	}
-	vbdID, err := uuid.FromString(vbdIDStr)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "vbd in publish context is not a valid UUID: %v", err)
-	}
-	if err := driver.xoClient.IsSRAttachedToVMHost(ctx, vbdID); err != nil {
-		return nil, status.Errorf(codes.Internal, "SR connectivity check failed for VBD %s: %v", vbdIDStr, err)
 	}
 
 	// Verify the device actually exists on this host before attempting to format/mount.

--- a/pkg/xenorchestra-csi/xenorchestra-csi.go
+++ b/pkg/xenorchestra-csi/xenorchestra-csi.go
@@ -50,10 +50,14 @@ type xenorchestraCSIDriver struct {
 	nodeMetadata clients.NodeMetadataGetter
 	xoClient     clients.XoClient
 	mounter      clients.Mounter
+	mode         DriverMode
 }
 
-// NewDriverWithDependencies is the internal constructor shared by NewDriver and NewStubDriver.
+// NewDriverWithDependencies is the internal constructor shared by NewDriver and tests.
 func NewDriverWithDependencies(options *DriverOptions, nodeMetadata clients.NodeMetadataGetter, xoClient clients.XoClient, mounter clients.Mounter) Driver {
+	if options.Mode == "" {
+		options.Mode = DriverModeController
+	}
 	if options.DriverName == "" {
 		klog.Fatal("no driver name provided")
 	}
@@ -68,6 +72,7 @@ func NewDriverWithDependencies(options *DriverOptions, nodeMetadata clients.Node
 	klog.Infof("VDI name prefix: %q", options.VDINamePrefix)
 	klog.Infof("Cluster tag: %q", options.ClusterTag)
 	klog.Infof("Kubernetes pool tag: %q", options.KubernetesPoolTag)
+
 	return &xenorchestraCSIDriver{
 		Name:              options.DriverName,
 		Version:           driverVersion,
@@ -78,11 +83,11 @@ func NewDriverWithDependencies(options *DriverOptions, nodeMetadata clients.Node
 		nodeMetadata:      nodeMetadata,
 		xoClient:          xoClient,
 		mounter:           mounter,
+		mode:              options.Mode,
 	}
 }
 
-func NewDriver(options *DriverOptions) Driver {
-	// Configure Kubernetes client
+func newKubernetesClient() kube.Interface {
 	kubeConfig, err := rest.InClusterConfig()
 	if err != nil {
 		klog.Fatalf("failed to get in-cluster config: %v", err)
@@ -92,6 +97,10 @@ func NewDriver(options *DriverOptions) Driver {
 		klog.Fatalf("failed to create kubernetes client: %v", err)
 	}
 
+	return kclient
+}
+
+func newXoSDKClient(options *DriverOptions) *xok8s.XoClient {
 	// Try to load XO config from mounted file first, then fallback to env
 	xoConfig, err := LoadXOConfigFromFile(options.ConfigFile)
 	if err != nil {
@@ -111,30 +120,35 @@ func NewDriver(options *DriverOptions) Driver {
 		klog.Fatalf("failed to create Xen Orchestra client: %v", err)
 	}
 
-	// Select the NodeMetadata implementation based on the configured source.
-	var nodeMetadataGetter clients.NodeMetadataGetter
-	switch options.NodeMetadataSource {
-	case NodeMetadataSourceXoAPI:
-		klog.Info("Node metadata source: xo-api (CCM not required)")
-		nodeMetadataGetter = clients.NewNodeMetadataFromXoClient(kclient, xoSDKClient, options.NodeName)
-	default:
-		if options.NodeMetadataSource != NodeMetadataSourceKubernetes {
-			klog.Fatalf("Unknown node-metadata-source %q", options.NodeMetadataSource)
-		}
-		klog.Info("Node metadata source: kubernetes (requires the XenOrchestra CCM)")
-		nodeMetadataGetter = clients.NewNodeMetadataFromKubernetes(kclient, options.NodeName)
+	return xoSDKClient
+}
+
+func NewDriver(options *DriverOptions) Driver {
+	kclient := newKubernetesClient()
+
+	var xoClient clients.XoClient
+	if options.Mode == DriverModeController {
+		xoSDKClient := newXoSDKClient(options)
+		xoClient = clients.NewXoClient(xoSDKClient.Client)
 	}
 
-	return NewDriverWithDependencies(options, nodeMetadataGetter, clients.NewXoClient(xoSDKClient.Client), clients.NewSafeMounter())
+	klog.Info("Node metadata source: kubernetes (requires the XenOrchestra CCM)")
+	nodeMetadataGetter := clients.NewNodeMetadataFromKubernetes(kclient, options.NodeName)
+
+	return NewDriverWithDependencies(options, nodeMetadataGetter, xoClient, clients.NewSafeMounter())
 }
 
 // Run implements Driver.
 func (driver *xenorchestraCSIDriver) Run(ctx context.Context) error {
-	// controllerServer := driver.GetController()
+	_ = ctx
 
-	// Start the nonblocking GRPC
 	grpc := NewNonBlockingGRPCServer()
-	grpc.Start(driver.endpoint, driver, driver, driver)
+	switch driver.mode {
+	case DriverModeNode:
+		grpc.Start(driver.endpoint, driver, nil, driver)
+	default:
+		grpc.Start(driver.endpoint, driver, driver, driver)
+	}
 
 	return nil
 }

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -54,13 +54,12 @@ func TestSanity(t *testing.T) {
 	driver, _ := NewFakeDriver(
 		t,
 		&xenorchestracsi.DriverOptions{
-			DriverName:         driverName,
-			NodeName:           nodeName,
-			Endpoint:           sanityEndpoint,
-			KubernetesPoolTag:  xenorchestracsi.DefaultKubernetesPoolTag,
-			NodeMetadataSource: xenorchestracsi.NodeMetadataSourceKubernetes,
-			VDINamePrefix:      xenorchestracsi.DefaultVDINamePrefix,
-			ClusterTag:         xenorchestracsi.DefaultClusterTag,
+			DriverName:        driverName,
+			NodeName:          nodeName,
+			Endpoint:          sanityEndpoint,
+			KubernetesPoolTag: xenorchestracsi.DefaultKubernetesPoolTag,
+			VDINamePrefix:     xenorchestracsi.DefaultVDINamePrefix,
+			ClusterTag:        xenorchestracsi.DefaultClusterTag,
 		},
 		fakeMounter)
 


### PR DESCRIPTION
## What? (description)

Add controller and node driver modes so the node server runs without XO configuration or credential-secret mounts.
The CSI driver now requires the Xen Orchestra CCM: node metadata is read from the CCM-provided Kubernetes Node ProviderID, and the direct XO API node metadata provider has been removed.

## Why? (reasoning)

Only the controller needs access to the Xen Orchestra API. Restricting XO credentials to the controller reduces the exposure of the credential secret, especially in clusters where control-plane and worker nodes are separated.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
