### PR TITLE
fix(helm): add volumeattributesclasses cluster role access

### DIFF
--- a/charts/xenorchestra-csi-driver/README.md
+++ b/charts/xenorchestra-csi-driver/README.md
@@ -160,3 +160,9 @@ for StorageClass examples, testing, and the full parameter reference.
 | sidecars.registrar.resources.requests.cpu | string | `"10m"` |  |
 | sidecars.registrar.resources.requests.memory | string | `"20Mi"` |  |
 | sidecars.registrar.resources.limits.memory | string | `"100Mi"` |  |
+| sidecars.resizer.image.repository | string | `"registry.k8s.io/sig-storage/csi-resizer"` |  |
+| sidecars.resizer.image.tag | string | `"v2.2.1"` |  |
+| sidecars.resizer.image.pullPolicy | string | `"IfNotPresent"` |  |
+| sidecars.resizer.resources.requests.cpu | string | `"10m"` |  |
+| sidecars.resizer.resources.requests.memory | string | `"20Mi"` |  |
+| sidecars.resizer.resources.limits.memory | string | `"100Mi"` |  |

--- a/charts/xenorchestra-csi-driver/templates/controller.yaml
+++ b/charts/xenorchestra-csi-driver/templates/controller.yaml
@@ -146,6 +146,24 @@ spec:
             periodSeconds: 20
           resources:
             {{- toYaml .Values.sidecars.provisioner.resources | nindent 12 }}
+        - name: csi-resizer
+          image: "{{ .Values.sidecars.resizer.image.repository }}:{{ .Values.sidecars.resizer.image.tag }}"
+          imagePullPolicy: {{ .Values.sidecars.resizer.image.pullPolicy }}
+          args:
+            - --v={{ .Values.driver.logVerbosityLevel }}
+            - --csi-address=/csi/csi.sock
+            - --http-endpoint=:29607
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 29607
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.sidecars.resizer.resources | nindent 12 }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/xenorchestra-csi-driver/templates/rbac.yaml
+++ b/charts/xenorchestra-csi-driver/templates/rbac.yaml
@@ -47,7 +47,7 @@ rules:
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "volumeattributesclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]

--- a/charts/xenorchestra-csi-driver/values.yaml
+++ b/charts/xenorchestra-csi-driver/values.yaml
@@ -143,3 +143,14 @@ sidecars:
         memory: 20Mi
       limits:
         memory: 100Mi
+  resizer:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-resizer
+      tag: v2.2.1
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 10m
+        memory: 20Mi
+      limits:
+        memory: 100Mi

--- a/docs/deploy/csi-driver-edge.yml
+++ b/docs/deploy/csi-driver-edge.yml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/version: "v1.0.0-rc.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: xenorchestra-csi-driver
+
 ---
 # Source: xenorchestra-csi-driver/templates/serviceaccounts.yaml
 apiVersion: v1
@@ -44,6 +45,7 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -71,7 +73,7 @@ rules:
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "volumeattributesclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
@@ -88,6 +90,7 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
+
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -109,6 +112,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: xenorchestra-csi-driver-node
+
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -412,6 +416,28 @@ spec:
             httpGet:
               path: /metrics
               port: 29606
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: csi-resizer
+          image: "registry.k8s.io/sig-storage/csi-resizer:v2.2.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --http-endpoint=:29607
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 29607
             initialDelaySeconds: 10
             periodSeconds: 20
           resources:

--- a/docs/deploy/csi-driver-microk8s.yml
+++ b/docs/deploy/csi-driver-microk8s.yml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/version: "v1.0.0-rc.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: xenorchestra-csi-driver
+
 ---
 # Source: xenorchestra-csi-driver/templates/serviceaccounts.yaml
 apiVersion: v1
@@ -44,6 +45,7 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -71,7 +73,7 @@ rules:
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "volumeattributesclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
@@ -88,6 +90,7 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
+
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -109,6 +112,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: xenorchestra-csi-driver-node
+
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -412,6 +416,28 @@ spec:
             httpGet:
               path: /metrics
               port: 29606
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: csi-resizer
+          image: "registry.k8s.io/sig-storage/csi-resizer:v2.2.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=2
+            - --csi-address=/csi/csi.sock
+            - --http-endpoint=:29607
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 29607
             initialDelaySeconds: 10
             periodSeconds: 20
           resources:

--- a/docs/deploy/csi-driver.yml
+++ b/docs/deploy/csi-driver.yml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/version: "v1.0.0-rc.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: xenorchestra-csi-driver
+
 ---
 # Source: xenorchestra-csi-driver/templates/serviceaccounts.yaml
 apiVersion: v1
@@ -44,6 +45,7 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -71,7 +73,7 @@ rules:
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "volumeattributesclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
@@ -88,6 +90,7 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
+
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -109,6 +112,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: xenorchestra-csi-driver-node
+
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -412,6 +416,28 @@ spec:
             httpGet:
               path: /metrics
               port: 29606
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: csi-resizer
+          image: "registry.k8s.io/sig-storage/csi-resizer:v2.2.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=2
+            - --csi-address=/csi/csi.sock
+            - --http-endpoint=:29607
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 29607
             initialDelaySeconds: 10
             periodSeconds: 20
           resources:


### PR DESCRIPTION
# Pull Request

## What? (description)

The csi driver can't access to volumeattributesclasses. So we have to give access :)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
