### PR TITLE
fix(chart): add missing flag `driver-name` to the csi-driver

### DIFF
--- a/charts/xenorchestra-csi-driver/templates/controller.yaml
+++ b/charts/xenorchestra-csi-driver/templates/controller.yaml
@@ -64,6 +64,7 @@ spec:
             - --v={{ .Values.driver.logVerbosityLevel }}
             - --mode=controller
             - --endpoint=unix:///csi/csi.sock
+            - --driver-name={{ .Values.driver.name }}
             - --node-name=$(KUBE_NODE_NAME)
             {{- if include "xenorchestra-csi-driver.configAvailable" . }}
             - --config-file=/etc/xenorchestra/config.yaml

--- a/charts/xenorchestra-csi-driver/templates/node.yaml
+++ b/charts/xenorchestra-csi-driver/templates/node.yaml
@@ -79,6 +79,7 @@ spec:
             - --v={{ .Values.driver.logVerbosityLevel }}
             - --mode=node
             - --endpoint=unix:///csi/csi.sock
+            - --driver-name={{ .Values.driver.name }}
             - --node-name=$(KUBE_NODE_NAME)
             {{- with .Values.driver.extraArgs }}
             {{- toYaml . | nindent 12 }}

--- a/charts/xenorchestra-csi-driver/values.yaml
+++ b/charts/xenorchestra-csi-driver/values.yaml
@@ -27,6 +27,8 @@ csidriver:
   enabled: true
 
 driver:
+  # Name registered by the driver binary (--driver-name), used as the CSIDriver
+  # object name and the kubelet plugin directory. Keep it consistent everywhere.
   name: csi.xenorchestra.vates.tech
   logVerbosityLevel: 2
   vdiNamePrefix: csi-

--- a/docs/deploy/csi-driver-edge.yml
+++ b/docs/deploy/csi-driver-edge.yml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/version: "v1.0.0-rc.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: xenorchestra-csi-driver
-
 ---
 # Source: xenorchestra-csi-driver/templates/serviceaccounts.yaml
 apiVersion: v1
@@ -45,7 +44,6 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,7 +88,6 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
-
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -112,7 +109,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: xenorchestra-csi-driver-node
-
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -222,6 +218,7 @@ spec:
             - --v=5
             - --mode=node
             - --endpoint=unix:///csi/csi.sock
+            - --driver-name=csi.xenorchestra.vates.tech
             - --node-name=$(KUBE_NODE_NAME)
           env:
             - name: KUBE_NODE_NAME
@@ -344,6 +341,7 @@ spec:
             - --v=5
             - --mode=controller
             - --endpoint=unix:///csi/csi.sock
+            - --driver-name=csi.xenorchestra.vates.tech
             - --node-name=$(KUBE_NODE_NAME)
             - --config-file=/etc/xenorchestra/config.yaml
             - --vdi-name-prefix=csi-

--- a/docs/deploy/csi-driver-microk8s.yml
+++ b/docs/deploy/csi-driver-microk8s.yml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/version: "v1.0.0-rc.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: xenorchestra-csi-driver
-
 ---
 # Source: xenorchestra-csi-driver/templates/serviceaccounts.yaml
 apiVersion: v1
@@ -45,7 +44,6 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,7 +88,6 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
-
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -112,7 +109,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: xenorchestra-csi-driver-node
-
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -222,6 +218,7 @@ spec:
             - --v=2
             - --mode=node
             - --endpoint=unix:///csi/csi.sock
+            - --driver-name=csi.xenorchestra.vates.tech
             - --node-name=$(KUBE_NODE_NAME)
           env:
             - name: KUBE_NODE_NAME
@@ -344,6 +341,7 @@ spec:
             - --v=2
             - --mode=controller
             - --endpoint=unix:///csi/csi.sock
+            - --driver-name=csi.xenorchestra.vates.tech
             - --node-name=$(KUBE_NODE_NAME)
             - --config-file=/etc/xenorchestra/config.yaml
             - --vdi-name-prefix=csi-

--- a/docs/deploy/csi-driver.yml
+++ b/docs/deploy/csi-driver.yml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/version: "v1.0.0-rc.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: xenorchestra-csi-driver
-
 ---
 # Source: xenorchestra-csi-driver/templates/serviceaccounts.yaml
 apiVersion: v1
@@ -45,7 +44,6 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,7 +88,6 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
-
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -112,7 +109,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: xenorchestra-csi-driver-node
-
 ---
 # Source: xenorchestra-csi-driver/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -222,6 +218,7 @@ spec:
             - --v=2
             - --mode=node
             - --endpoint=unix:///csi/csi.sock
+            - --driver-name=csi.xenorchestra.vates.tech
             - --node-name=$(KUBE_NODE_NAME)
           env:
             - name: KUBE_NODE_NAME
@@ -344,6 +341,7 @@ spec:
             - --v=2
             - --mode=controller
             - --endpoint=unix:///csi/csi.sock
+            - --driver-name=csi.xenorchestra.vates.tech
             - --node-name=$(KUBE_NODE_NAME)
             - --config-file=/etc/xenorchestra/config.yaml
             - --vdi-name-prefix=csi-


### PR DESCRIPTION
## What? (description)

Add the arg `--driver-name` to the controller and the node deployments to match the value `driver.name`.

## Why? (reasoning)

When using the value `driver.name` the driver-name flag wasn't changed and the CSI registers itself with the internal hard-coded name: `csi.xenorchestra.vates.tech`.
It results in a mismatch between the driver name in the Kubernetes resource (the content of `Values.driver.name`) and the actual provisioner name you need to use in the storage class (`csi.xenorchestra.vates.tech`).

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
